### PR TITLE
NPM allproxy script not working

### DIFF
--- a/bin/allproxy
+++ b/bin/allproxy
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 BIN_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SYMLINK=$(readlink "${BASH_SOURCE[0]}")
+if [ ! -z "$SYMLINK" ]; then
+  BIN_DIR=$BIN_DIR/$(dirname $SYMLINK)
+fi
+
 if [ -f "$BIN_DIR/../app.ts" ]; then
   DATA_DIR=$BIN_DIR/../
 else

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "description": "AllProxy: HTTP, SQL, gRPC Debugging Tool.",
   "keywords": [
     "proxy",


### PR DESCRIPTION
allproxy script does not follow the symbolic link when locating build directory for AllProxy server.  This only affects NPM packages.