### PR TITLE
Experimental gRPC forward proxy

### DIFF
--- a/bin/allproxy
+++ b/bin/allproxy
@@ -18,4 +18,4 @@ if [ ! -d "$DATA_DIR" ]; then
   mkdir $DATA_DIR
 fi
 
-node $BIN_DIR/../build/app
+node $BIN_DIR/../build/app $@

--- a/client/src/common/ProxyConfig.ts
+++ b/client/src/common/ProxyConfig.ts
@@ -38,15 +38,4 @@ export default class ProxyConfig {
 			this.comment = proxyConfig.comment;
 		}
 	}
-
-	static isHttpOrHttps(config: ProxyConfig): boolean {
-		switch (config.protocol) {
-			case 'http:':
-			case 'https:':
-			case 'browser:':
-				return true;
-			default:
-				return false;
-		}
-	}
 }

--- a/common/ProxyConfig.ts
+++ b/common/ProxyConfig.ts
@@ -23,15 +23,4 @@ export default class ProxyConfig {
   logProxyProcess?: any = undefined;
   _server?: net.Server | tls.Server;
   comment:string = '';
-
-  static isHttpOrHttps (config: ProxyConfig): boolean {
-    switch (config.protocol) {
-      case 'http:':
-      case 'https:':
-      case 'browser:':
-        return true
-      default:
-        return false
-    }
-  }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,4 +58,4 @@ services:
       - 50067
       - 50068
       - 63790
-    command: 'yarn start --listen 8888 --listenHttps 9999'
+    command: 'yarn start --listenHttp 8888 --listenHttps 9999 --listenGrpc 7777'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "AllProxy: HTTP, SQL, gRPC Debugging Tool.",
   "keywords": [
     "proxy",


### PR DESCRIPTION
Add --listenGrpc and --listenSecureGrpc experimental options for gRPC forward proxy.   The gRPC reverse proxy has already been implemented and is stable.