### PR TITLE
Feature to modify/replace HTTPS responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ AllProxy is similar to Fiddler and Charles, but in addition to HTTP(S), it also 
   * [Pause Recording](#pause-recording)
   * [Filter Messages](#filter-messages)
   * [Resend HTTP Requests](#resend-http-requests)
+  * [Modify HTTPS Responses](#modify-https-responses)
   * [Snapshots](#snapshots)
   * [Multiple Browser Tabs](#multiple-browser-tabs)
 * [Certificates](#certificates)
@@ -288,6 +289,22 @@ Boolean filters can use &&, ||, !, and parenthesis.
 
 ### Resend HTTP Requests
 To resend an HTTP or HTTPS request, click on the icon next to the request to open a modal.  Optionally modify the request body, and then click the send button.  If the dashboard is not paused, the resent request should appear at the bottom of the dashboard request log.
+
+### Modify HTTPS Responses
+An HTTPS response can be replaced with your own hard coded response.  Simply create a file in the **replace-responses** directory matching the request URL path.
+
+For example:
+* To replace responses for URL https://myapp/lib/js/test.js
+
+Create test.js file in **replace-responses** directory.  It's path must match the URL: /lib/js/test.js.
+```sh
+$ cd allproxy/replace-responses
+replace-responses$ mkdir -p lib/js
+replace-responses$ echo 'My test response' > test.js
+```
+WHenever AllProxy receives URL /lib/js/test.js, it will replace the response with the content from file replace-responses/lib/js/test.js.
+
+Note, the AllProxy must be restarted after adding new files to the **replace-responses** directory.
 
 ### Snapshots
 Clicking on the camera icon will take a snapshot of the currently captured messages, and create a new snapshot tab.  A snapshot tab may be exported to a file, and later imported again.

--- a/bin/allproxy
+++ b/bin/allproxy
@@ -18,4 +18,9 @@ if [ ! -d "$DATA_DIR" ]; then
   mkdir $DATA_DIR
 fi
 
+REPLACE_RESPONSES_DIR=$DATA_DIR/replace-responses
+if [ ! -d "$REPLACE_RESPONSES_DIR" ]; then
+  mkdir $REPLACE_RESPONSES_DIR
+fi
+
 node $BIN_DIR/../build/app $@

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "AllProxy: HTTP, SQL, gRPC Debugging Tool.",
   "keywords": [
     "proxy",

--- a/replace-responses/includes/js/app/modules/custom_fields.js
+++ b/replace-responses/includes/js/app/modules/custom_fields.js
@@ -1,0 +1,63 @@
+(function () {
+    var customFieldsListTemplate;
+    var customFieldsTemplates;
+
+    function getTemplates() {
+        customFieldsListTemplate = _.template($('#customFieldsListTemplate').text());
+        customFieldsTemplates = {
+            picklist: _.template($('#customFieldsPicklistTemplate').text()),
+            checkbox: _.template($('#customFieldsCheckboxTemplate').text()),
+            textarea: _.template($('#customFieldsTextareaTemplate').text()),
+            input: _.template($('#customFieldsInputTemplate').text()),
+            upload: _.template($('#customFieldsUploadTemplate').text()),
+            boolean: _.template($('#customFieldsBooleanTemplate').text()),
+        };
+    }
+
+    var CustomFieldsModule = function (opts) {
+        this.options = opts || {};
+
+        this.render = function (target) {
+            if (!customFieldsListTemplate) {
+                getTemplates();
+            }
+
+            var $el = target || this.options.el;
+            $el = $el instanceof $ ? $el : $($el);
+            var html = customFieldsListTemplate({
+                fields: this.options.fields || {},
+                values: this.options.values || {},
+                textareas: this.options.textareas || {},
+                folders: this.options.folders || {},
+                folderOrder: this.options.folderOrder || null,
+                pipelineFilters: this.options.pipelineFilters || {},
+                item: this.options.item || {id: 0},
+                itemType: this.options.itemType || '',
+                fieldClass: this.options.fieldClass + ' ' || '',
+                templates: customFieldsTemplates,
+                fieldFilter: _.isFunction(this.options.fieldFilter) ? this.options.fieldFilter : null,
+            });
+            $el.html(html);
+
+            $el.find('.datepicker').datepicker({
+                dateFormat: 'yy-mm-dd',
+                onSelect: function (dateText) {
+                    $(this).attr('value', dateText).change();
+                },
+            });
+
+            $el.find('.datetimepicker').each(function () {
+                const format = $(this).attr('format');
+                console.log('custom_fields format:', format);
+                $(this).datetimepicker({
+                    defaultTime: '00:00:00',
+                    format: format || 'Y-m-d H:i:s',
+                });
+            });
+        };
+    };
+
+    // todo - proper module?
+    window.CustomFieldsModule = CustomFieldsModule;
+    return CustomFieldsModule;
+})();

--- a/server/src/Paths.ts
+++ b/server/src/Paths.ts
@@ -14,6 +14,10 @@ export default class Paths {
     return Paths.platform(`${Paths.dataDir}config.json`)
   }
 
+  public static replaceResponsesDir (): string {
+    return Paths.platform(`${Paths.dataDir}replace-responses/`)
+  }
+
   public static sslCaDir (): string {
     return Paths.platform(`${Paths.dataDir}.http-mitm-proxy`)
   }

--- a/server/src/ReplaceResponse.ts
+++ b/server/src/ReplaceResponse.ts
@@ -1,0 +1,38 @@
+import fs from 'fs'
+import Paths from './Paths'
+import { exec } from 'child_process'
+
+const files: {[key:string]:string} = {}
+let filesRead = false
+
+export default function replaceResponse (url: string): Buffer | null {
+  if (!filesRead) {
+    filesRead = true
+    const command = `find ${Paths.replaceResponsesDir()} -type f`
+    // console.log('replaceResponse', command)
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.log(error)
+      }
+      if (stderr) {
+        console.log(stderr)
+      }
+      if (stdout) {
+        for (const file of stdout.split('\n')) {
+          if (file.length > 0) {
+            const url = file.substr(Paths.replaceResponsesDir().length - 1)
+            console.log('Found file in replace-responses directory for url:', url)
+            files[url] = file
+          }
+        }
+      }
+    })
+  }
+
+  const path = files[url]
+  if (path) {
+    console.log('Replacing response for url', url)
+    return fs.readFileSync(path)
+  }
+  return null
+}


### PR DESCRIPTION
An HTTPS response can be replaced with your own hard coded response.  Simply create a file in the **replace-responses** directory matching the request URL path.

For example:
* To replace responses for URL https://myapp/lib/js/test.js

Create test.js file in **replace-responses** directory.  It's path must match the URL: /lib/js/test.js.
```sh
$ cd allproxy/replace-responses
replace-responses$ mkdir -p lib/js
replace-responses$ echo 'My test response' > test.js
```
WHenever AllProxy receives URL /lib/js/test.js, it will replace the response with the content from file replace-responses/lib/js/test.js.

Note, the AllProxy must be restarted after adding new files to the **replace-responses** directory.