### PR TITLE
Secure HTTP/2 support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,5 +20,6 @@
         "@typescript-eslint"
     ],
     "rules": {
+        "semi": [ 2, "always" ]
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AllProxy is similar to Fiddler and Charles, but in addition to HTTP(S), it also 
 * take snapshots of captured messages
 * export and import captured messages
 * supports multiple dashboard browser tabs
+* HTTP/2 support
 
 ### Table of Contents
 
@@ -26,7 +27,8 @@ AllProxy is similar to Fiddler and Charles, but in addition to HTTP(S), it also 
   * [Configure Browser Proxy](#configure-browser-proxy)
 * [Screenshots](#screenshots)
 * [Configuration](#configuration)
-  * [HTTP/HTTPS Proxy](http-https-proxy)
+  * [HTTP/HTTPS Proxy](#http-https-proxy)
+  * [HTTP/2 Support](#http2-support)
   * [MySQL Proxy](#mysql-proxy)
   * [gRPC Proxy](#grpc-Proxy)
   * [MongoDB Proxy](#mongodb-proxy)
@@ -173,6 +175,12 @@ ELASTIC_PORT=8888       # allproxy HTTP port is 8888.  Use 9999 for HTTPS.
 
 An HTTP path is added to proxy HTTP requests to the elasticsearch host.  All HTTP requests matching path /_search are proxied to the elasticsearch host on port 9200.
 ![ ](https://github.com/davechri/allproxy/blob/master/images/elasticsearch-settings.png)
+
+<h3 id="http2-support">HTTP/2 Support</h3>
+You can use HTTP/2 to connect to HTTP/2 enabled servers (e.g., duckduckgo.com).  To enable HTTP/2:
+```sh
+$ allproxy --http2
+```
 
 ### MySQL Proxy
 The SQL proxy can transparently capture SQL messages sent by backend microservices to a MySQL server.

--- a/app.ts
+++ b/app.ts
@@ -1,145 +1,153 @@
-import http from 'http'
-import { exit } from 'process'
-import https from 'https'
-import Global from './server/src/Global'
-import SocketIoManager from './server/src/SocketIoManager'
-import HttpProxy from './server/src/HttpProxy'
-import HttpsProxy from './server/src/HttpsProxy'
-import HttpMitmProxy from './node-http-mitm-proxy'
-import Paths from './server/src/Paths'
-import GrpcProxy from './server/src/GrpcProxy'
-import PortConfig from './common/PortConfig'
-const httpMitmProxy = HttpMitmProxy()
+import http from 'http';
+import { exit } from 'process';
+import https from 'https';
+import Global from './server/src/Global';
+import SocketIoManager from './server/src/SocketIoManager';
+import HttpProxy from './server/src/HttpProxy';
+import HttpMitmProxy from './node-http-mitm-proxy';
+import Paths from './server/src/Paths';
+import GrpcProxy from './server/src/GrpcProxy';
+import PortConfig from './common/PortConfig';
+import HttpsProxy, { HttpVersion } from './server/src/HttpsProxy';
+import Https1Proxy from './server/src/Https1Proxy';
+const httpMitmProxy = HttpMitmProxy();
 
 const listen: {
   protocol: string,
   host?: string,
   port: number
-}[] = []
+}[] = [];
 
-let httpServer: http.Server | https.Server
+let httpServer: http.Server | https.Server;
+let useHttp2 = false;
 
-console.log(process.argv)
+console.log(process.argv);
 
 for (let i = 2; i < process.argv.length; ++i) {
   switch (process.argv[i]) {
     case '--help':
-      usage()
-      exit(1)
-      break
+      usage();
+      exit(1);
+      break;
     case '--listen':
     case '--listenHttp':
     case '--listenHttps':
     case '--listenGrpc':
     case '--listenSecureGrpc': {
       if (i + 1 >= process.argv.length) {
-        usage()
-        console.error('\nMissing port number for ' + process.argv[i])
+        usage();
+        console.error('\nMissing port number for ' + process.argv[i]);
       }
 
-      let protocol : 'http:' | 'https:' | 'grpc:' | 'securegrpc:' = 'http:'
+      let protocol : 'http:' | 'https:' | 'grpc:' | 'securegrpc:' = 'http:';
       switch (process.argv[i]) {
         case '--listen':
         case '--listenHttp':
-          protocol = 'http:'
-          break
+          protocol = 'http:';
+          break;
         case '--listenHttps':
-          protocol = 'https:'
-          break
+          protocol = 'https:';
+          break;
         case '--listenGrpc':
-          protocol = 'grpc:'
-          break
+          protocol = 'grpc:';
+          break;
         case '--listenSecureGrpc':
-          protocol = 'securegrpc:'
-          break
+          protocol = 'securegrpc:';
+          break;
       }
-      let host
-      let port = process.argv[++i]
-      const tokens = port.split(':')
+      let host;
+      let port = process.argv[++i];
+      const tokens = port.split(':');
       if (tokens.length > 1) {
-        host = tokens[0]
-        port = tokens[1]
+        host = tokens[0];
+        port = tokens[1];
       }
 
-      const portNum: number = +port
+      const portNum: number = +port;
       listen.push({
         protocol,
         host,
         port: portNum
-      })
+      });
 
-      break
+      break;
     }
+    case '--http2':
+      useHttp2 = true;
+      break;
     default:
-      usage()
-      console.error('\nInvalid option: ' + process.argv[i])
-      exit(1)
+      usage();
+      console.error('\nInvalid option: ' + process.argv[i]);
+      exit(1);
   }
 }
 
 if (listen.length === 0) {
-  listen.push({ protocol: 'http:', port: 8888 })
-  listen.push({ protocol: 'https:', port: 9999 })
+  listen.push({ protocol: 'http:', port: 8888 });
+  listen.push({ protocol: 'https:', port: 9999 });
 }
 
 function usage () {
-  console.log('\nUsage: npm start [--listen [host:]port] [--listenHttps [host:]port] [--debug]')
-  console.log('\nOptions:')
-  console.log('\t--listenHttp - listen for incoming http connections.  Default is 8888.')
-  console.log('\t--listenHttps - listen for incoming https connections. Defaults is 9999.')
-  console.log('\t--listenGrpc - listen for incoming gRPC connections. (experimental)')
-  console.log('\t--listenSecureGrpc - listen for incoming secure gRPC connections. (experimental)')
-  console.log('\nExample: npm start -- --listen 8888 --listenHttps 9999')
+  console.log('\nUsage: npm start [--listen [host:]port] [--listenHttps [host:]port] [--debug]');
+  console.log('\nOptions:');
+  console.log('\t--listenHttp - listen for incoming http connections.  Default is 8888.');
+  console.log('\t--listenHttps - listen for incoming https connections. Defaults is 9999.');
+  console.log('\t--http2 - Enable HTTP/2 for https connections. (Experimental)');
+  console.log('\nExample: npm start -- --listen 8888 --listenHttps 9999');
 }
 
 /**
  * Exception handler.
  */
 process.on('uncaughtException', (err) => {
-  console.error(err.stack)
+  console.error(err.stack);
   // process.exit()
-})
+});
 
-Paths.makeCaPemSymLink()
+Paths.makeCaPemSymLink();
 
-Global.portConfig = new PortConfig()
-Global.socketIoManager = new SocketIoManager()
-const httpProxy = new HttpProxy()
-const httpsProxy = new HttpsProxy()
+Global.portConfig = new PortConfig();
+Global.socketIoManager = new SocketIoManager();
+const httpProxy = new HttpProxy();
+const https1Proxy = new Https1Proxy();
 
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0' // trust all certificates
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // trust all certificates
 
 for (const entry of listen) {
-  const protocol = entry.protocol
-  const host = entry.host
-  const port = entry.port
+  const protocol = entry.protocol;
+  const host = entry.host;
+  const port = entry.port;
 
   switch (protocol) {
     case 'https:':
-      httpMitmProxy.listen({ port: port, sslCaDir: Paths.sslCaDir() })
-      console.log(`Listening on ${protocol} ${host || ''} ${port}`)
-      httpsProxy.onRequest(httpMitmProxy)
-      Global.portConfig.httpsPort = port
-      break
+      httpMitmProxy.listen({ port: port, sslCaDir: Paths.sslCaDir() });
+      console.log(`Listening on ${protocol} ${host || ''} ${port}`);
+      if (useHttp2) {
+        HttpsProxy.start(HttpVersion.HTTP2, port);
+      } else {
+        https1Proxy.onRequest(httpMitmProxy);
+      }
+      Global.portConfig.httpsPort = port;
+      break;
     case 'http:':
       httpServer = http.createServer(
-        (clientReq, clientRes) => httpProxy.onRequest(clientReq, clientRes))
-      httpServer.listen(port, host)
-      console.log(`Listening on ${protocol} ${host || ''} ${port}`)
-      console.log(`Open browser to ${protocol}//localhost:${port}/allproxy\n`)
+        (clientReq, clientRes) => httpProxy.onRequest(clientReq, clientRes));
+      httpServer.listen(port, host);
+      console.log(`Listening on ${protocol} ${host || ''} ${port}`);
+      console.log(`Open browser to ${protocol}//localhost:${port}/allproxy\n`);
 
-      Global.socketIoManager.addHttpServer(httpServer)
-      Global.portConfig.httpPort = port
-      break
+      Global.socketIoManager.addHttpServer(httpServer);
+      Global.portConfig.httpPort = port;
+      break;
     case 'grpc:':
-      GrpcProxy.forwardProxy(port, false)
-      console.log(`Listening on gRPC ${host || ''} ${port}`)
-      Global.portConfig.grpcPort = port
-      break
+      GrpcProxy.forwardProxy(port, false);
+      console.log(`Listening on gRPC ${host || ''} ${port}`);
+      Global.portConfig.grpcPort = port;
+      break;
     case 'securegrpc:':
-      GrpcProxy.forwardProxy(port, true)
-      console.log(`Listening on secure gRPC ${host || ''} ${port}`)
-      Global.portConfig.grpcSecurePort = port
-      break
+      GrpcProxy.forwardProxy(port, true);
+      console.log(`Listening on secure gRPC ${host || ''} ${port}`);
+      Global.portConfig.grpcSecurePort = port;
+      break;
   }
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,4 +58,4 @@ services:
       - 50067
       - 50068
       - 63790
-    command: 'yarn start --listenHttp 8888 --listenHttps 9999 --listenGrpc 7777'
+    command: 'yarn start --listenHttp 8888 --listenHttps 9999'

--- a/node-http-mitm-proxy/index.d.ts
+++ b/node-http-mitm-proxy/index.d.ts
@@ -1,27 +1,28 @@
-//definitions by jason swearingen.  jasons aat novaleaf doot coom.  for node-htt-mitm-proxy v0.5.2.  
+// definitions by jason swearingen.  jasons aat novaleaf doot coom.  for node-htt-mitm-proxy v0.5.2.
 
- import http = require("http");
- import https = require("https");
- import net = require("net");
-
+ import http = require('http');
+ import https = require('https');
+ import net = require('net');
 
  declare namespace HttpMitmProxy {
      export interface IProxyStatic {
          (): IProxy;
-         /** mod to pass to the use() function: Gunzip response filter (uncompress gzipped content before onResponseData and compress back after)*/
+         /** mod to pass to the use() function: Gunzip response filter (uncompress gzipped content before onResponseData and compress back after) */
          gunzip: any;
-         /** mod to pass to the use() function: Generates wilcard certificates by default (so less certificates are generated)*/
+         /** mod to pass to the use() function: Generates wilcard certificates by default (so less certificates are generated) */
          wildcard: any;
+
+         ca: any;
      }
 
      export interface IProxyOptions {
-         /**port - The port or named socket to listen on (default: 8080).*/
+         /** port - The port or named socket to listen on (default: 8080). */
          port?: number;
-         /**host - The hostname or local address to listen on.*/
+         /** host - The hostname or local address to listen on. */
          host?: string;
-         /** - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy')*/
+         /** - Path to the certificates cache directory (default: process.cwd() + '/.http-mitm-proxy') */
          sslCaDir?: string;
-         /**  - enable HTTP persistent connection*/
+         /**  - enable HTTP persistent connection */
          keepAlive?: boolean;
          /**  - The number of milliseconds of inactivity before a socket is presumed to have timed out. Defaults to no timeout. */
          timeout?: number;
@@ -42,17 +43,16 @@
          listen(/** An object with the following options: */ options?: IProxyOptions, callback?: Function): void;
          /** proxy.close
          Stops the proxy listening.
-        
+
          Example
-        
+
          proxy.close(); */
          close(): void;
-
 
          onCertificateRequired(hostname: string, callback: (error: Error | undefined, certDetails: { keyFile: string; certFile: string; hosts: string[]; }) => void): void;
          onCertificateMissing(ctx: IContext, files: any, callback: (error: Error | undefined, certDetails: { keyFileData: string; certFileData: string; hosts: string[]; }) => void): void;
 
-         //undocumented helpers
+         // undocumented helpers
          onConnect(fcn: (req: http.IncomingMessage, socket: net.Socket, head: any, callback: (error?: Error) => void) => void): void;
          onRequestHeaders(fcn: (ctx: IContext, callback: (error?: Error) => void) => void): void;
          onResponseHeaders(fcn: (ctx: IContext, callback: (error?: Error) => void) => void): void;
@@ -80,19 +80,19 @@
 
      /** signatures for various callback functions */
      export interface ICallbacks {
-         onError(/**Adds a function to the list of functions to get called if an error occures.
+         onError(/** Adds a function to the list of functions to get called if an error occures.
 
  Arguments
 
- fn(ctx, err, errorKind) - The function to be called on an error.*/callback: (context: IContext, err?: Error, errorKind?: string) => void): void;
+ fn(ctx, err, errorKind) - The function to be called on an error. */callback: (context: IContext, err?: Error, errorKind?: string) => void): void;
 
          /** Adds a function to get called at the beginning of a request.
-        
+
          Arguments
-        
+
          fn(ctx, callback) - The function that gets called on each request.
          Example
-        
+
          proxy.onRequest(function(ctx, callback) {
            console.log('REQUEST:', ctx.clientToProxyRequest.url);
            return callback();
@@ -103,12 +103,12 @@
 
          onRequestEnd(fcn: (ctx: IContext, callback: (error?: Error) => void) => void): void;
          /** Adds a function to get called at the beginning of the response.
-        
+
          Arguments
-        
+
          fn(ctx, callback) - The function that gets called on each response.
          Example
-        
+
          proxy.onResponse(function(ctx, callback) {
            console.log('BEGIN RESPONSE');
            return callback();
@@ -146,10 +146,7 @@
              Proxy.wildcard Generates wilcard certificates by default (so less certificates are generated) */
          use(mod: any): void;
 
-
-
      }
-
 
      export type IContext = ICallbacks & {
          isSSL: boolean;
@@ -161,7 +158,6 @@
          proxyToClientResponse: http.ServerResponse;
          proxyToServerRequest: http.ClientRequest;
          serverToProxyResponse: http.IncomingMessage;
-
 
          /** instance of WebSocket object from https://github.com/websockets/ws */
          clientToProxyWebSocket: any;
@@ -179,7 +175,7 @@
              [key: string]: any;
          }
 
-         /**Adds a stream into the request body stream.
+         /** Adds a stream into the request body stream.
 
  Arguments
 
@@ -204,7 +200,7 @@
          /** filters added by .addResponseFilter() */
          responseFilters: any[];
 
-         /** undocumented, allows adjusting the request in callbacks (such as .onRequest()) before sending  upstream (to proxy or target host)..  
+         /** undocumented, allows adjusting the request in callbacks (such as .onRequest()) before sending  upstream (to proxy or target host)..
           * FYI these values seem pre-populated with defaults based on the request, you can modify them to change behavior. */
          proxyToServerRequestOptions: {
              /** ex: "GET" */
@@ -223,11 +219,9 @@
          onResponseDataHandlers:Function[];
          onResponseEndHandlers:Function[];
 
-
-
      }
  }
 
- declare const HttpMitmProxy: HttpMitmProxy.IProxyStatic
+declare const HttpMitmProxy: HttpMitmProxy.IProxyStatic;
  export = HttpMitmProxy;
  export as namespace HttpMitmProxy;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allproxy",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "allproxy",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "allproxy",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "AllProxy: HTTP, SQL, gRPC Debugging Tool.",
   "keywords": [
     "proxy",
     "debug",
     "mitm",
     "http",
+    "https",
+    "http2",
     "sql",
     "grpc",
     "tcp"

--- a/server/src/AllProxyApp.ts
+++ b/server/src/AllProxyApp.ts
@@ -1,71 +1,71 @@
-import { ServerResponse } from 'http'
-import { Http2ServerResponse } from 'http2'
-import path from 'path'
-import { UrlWithStringQuery } from 'url'
-import Paths from './Paths'
-import fs from 'fs'
-import Global from './Global'
+import { ServerResponse } from 'http';
+import { Http2ServerResponse } from 'http2';
+import path from 'path';
+import { UrlWithStringQuery } from 'url';
+import Paths from './Paths';
+import fs from 'fs';
+import Global from './Global';
 
 const AllProxyApp = (
   clientRes: ServerResponse | Http2ServerResponse,
   reqUrl: UrlWithStringQuery
 ): boolean => {
-  let responseSent = true
-  const clientBuildDir = Paths.clientDir() + path.sep + 'build'
+  let responseSent = true;
+  const clientBuildDir = Paths.clientDir() + path.sep + 'build';
 
   if (reqUrl.pathname === '/' + 'anyproxy' || reqUrl.pathname === '/' + 'allproxy') {
     clientRes.writeHead(200, {
       'content-type': 'text/html'
-    })
-    clientRes.end(fs.readFileSync(clientBuildDir + path.sep + 'index.html'))
+    });
+    clientRes.end(fs.readFileSync(clientBuildDir + path.sep + 'index.html'));
   } else {
-    const dir = clientBuildDir + reqUrl.pathname?.replace(/\//g, path.sep)
+    const dir = clientBuildDir + reqUrl.pathname?.replace(/\//g, path.sep);
     // File exists locally?
     if (reqUrl.protocol === null &&
               fs.existsSync(dir) && fs.lstatSync(dir).isFile()) {
-      const extname = path.extname(reqUrl.pathname!)
-      let contentType = 'text/html'
+      const extname = path.extname(reqUrl.pathname!);
+      let contentType = 'text/html';
       switch (extname) {
         case '.js':
-          contentType = 'text/javascript'
-          break
+          contentType = 'text/javascript';
+          break;
         case '.css':
-          contentType = 'text/css'
-          break
+          contentType = 'text/css';
+          break;
         case '.json':
-          contentType = 'application/json'
-          break
+          contentType = 'application/json';
+          break;
         case '.png':
-          contentType = 'image/png'
-          break
+          contentType = 'image/png';
+          break;
         case '.jpg':
-          contentType = 'image/jpg'
-          break
+          contentType = 'image/jpg';
+          break;
         case '.wav':
-          contentType = 'audio/wav'
-          break
+          contentType = 'audio/wav';
+          break;
       }
 
       // Read local file and return to client
       clientRes.writeHead(200, {
         'content-type': contentType
-      })
-      clientRes.end(fs.readFileSync(clientBuildDir + reqUrl.pathname))
+      });
+      clientRes.end(fs.readFileSync(clientBuildDir + reqUrl.pathname));
     } else if (reqUrl.protocol === null &&
               reqUrl.pathname === '/api/allproxy/config') {
       Global.socketIoManager.updateHostReachable()
         .then((configs) => {
           clientRes.writeHead(200, {
             'content-type': 'application/json'
-          })
-          clientRes.end(JSON.stringify(configs, null, 2))
-        })
+          });
+          clientRes.end(JSON.stringify(configs, null, 2));
+        });
     } else {
-      responseSent = false
+      responseSent = false;
     }
   }
 
-  return responseSent
-}
+  return responseSent;
+};
 
-export default AllProxyApp
+export default AllProxyApp;

--- a/server/src/DecompressResponse.ts
+++ b/server/src/DecompressResponse.ts
@@ -1,0 +1,12 @@
+import zlib from 'zlib';
+
+export default function decompressResponse (headers: {[key:string]: any}, data: Buffer): Buffer {
+  if (headers['content-encoding'] === 'gzip') {
+    delete headers['content-encoding'];
+    data = zlib.gunzipSync(data);
+  } else if (headers['content-encoding'] === 'br') {
+    delete headers['content-encoding'];
+    data = zlib.brotliDecompressSync(data);
+  }
+  return data;
+}

--- a/server/src/GenerateCertKey.ts
+++ b/server/src/GenerateCertKey.ts
@@ -1,0 +1,20 @@
+import Proxy from '../../node-http-mitm-proxy';
+import Paths from './Paths';
+
+let theCa: any;
+Proxy.ca.create(Paths.sslCaDir(), function (_err: any, ca: any) {
+  theCa = ca;
+});
+
+const generateCertKey = async (host: string): Promise<{cert: string, key: string}> => {
+  return new Promise((resolve) => {
+    theCa.generateServerCertificateKeys([host], function (certPEM: string, privateKeyPEM: string) {
+      resolve({
+        cert: certPEM,
+        key: privateKeyPEM
+      });
+    });
+  });
+};
+
+export default generateCertKey;

--- a/server/src/Global.ts
+++ b/server/src/Global.ts
@@ -1,6 +1,6 @@
-import SocketIoManager from './SocketIoManager'
-import dns from 'dns'
-import PortConfig from '../../common/PortConfig'
+import SocketIoManager from './SocketIoManager';
+import dns from 'dns';
+import PortConfig from '../../common/PortConfig';
 
 export default class Global {
     static socketIoManager: SocketIoManager;
@@ -12,24 +12,24 @@ export default class Global {
       return new Promise<string>((resolve) => {
         if (ipAddr) {
           try {
-            ipAddr = ipAddr.replace('::ffff:', '')
+            ipAddr = ipAddr.replace('::ffff:', '');
             dns.reverse(ipAddr, (err: any, hosts: any) => {
               if (err === null && hosts.length > 0) {
-                ipAddr = hosts.sort((a:string, b:string) => a.length - b.length)[0]
-                const host = ipAddr!.split('.')[0] // un-qualify host name
+                ipAddr = hosts.sort((a:string, b:string) => a.length - b.length)[0];
+                const host = ipAddr!.split('.')[0]; // un-qualify host name
                 if (isNaN(+host)) {
-                  ipAddr = host
+                  ipAddr = host;
                 }
               }
-              resolve(ipAddr!)
-            })
+              resolve(ipAddr!);
+            });
           } catch (e) {
-            resolve(ipAddr)
+            resolve(ipAddr);
           }
         } else {
-          ipAddr = 'unknown'
-          resolve(ipAddr)
+          ipAddr = 'unknown';
+          resolve(ipAddr);
         }
-      })
+      });
     }
 }

--- a/server/src/GrpcProxy.ts
+++ b/server/src/GrpcProxy.ts
@@ -1,36 +1,38 @@
-import url from 'url'
-import http2, { Http2ServerRequest, Http2ServerResponse } from 'http2'
-import Global from './Global'
-import ProxyConfig from '../../common/ProxyConfig'
-import HttpMessage from './HttpMessage'
-import querystring from 'querystring'
-import HexFormatter from './formatters/HexFormatter'
-import Paths from './Paths'
-import fs from 'fs'
+import url from 'url';
+import http2, { Http2ServerRequest, Http2ServerResponse } from 'http2';
+import Global from './Global';
+import ProxyConfig from '../../common/ProxyConfig';
+import HttpMessage from './HttpMessage';
+import querystring from 'querystring';
+import HexFormatter from './formatters/HexFormatter';
+import Paths from './Paths';
+import fs from 'fs';
+import listen from './Listen';
+import decompressResponse from './DecompressResponse';
 
-const debug = false
+const debug = false;
 
-const settings = { maxConcurrentStreams: undefined }
+const settings = { maxConcurrentStreams: undefined };
 
 const tlsOptions = {
   key: fs.readFileSync(Paths.serverKey()),
   cert: fs.readFileSync(Paths.serverCrt())
-}
+};
 
 /**
  * Important: This module must remain at the project root to properly set the document root for the index.html.
  */
 export default class GrpcProxy {
   public static forwardProxy (port: number, isSecure: boolean = false) {
-    const proxyConfig = new ProxyConfig()
-    proxyConfig.isSecure = isSecure
-    proxyConfig.protocol = 'grpc:'
-    proxyConfig.path = port.toString()
-    GrpcProxy.start(proxyConfig, true)
+    const proxyConfig = new ProxyConfig();
+    proxyConfig.isSecure = isSecure;
+    proxyConfig.protocol = 'grpc:';
+    proxyConfig.path = port.toString();
+    GrpcProxy.start(proxyConfig, true);
   }
 
   public static reverseProxy (proxyConfig: ProxyConfig) {
-    GrpcProxy.start(proxyConfig)
+    GrpcProxy.start(proxyConfig);
   }
 
   private static start (proxyConfig: ProxyConfig, isForwardProxy = false) {
@@ -41,42 +43,24 @@ export default class GrpcProxy {
       })
       : http2.createServer({
         settings
-      })
+      });
 
     if (!isForwardProxy) {
-      proxyConfig._server = server
+      proxyConfig._server = server;
     }
 
-    listen(server)
+    listen('GrpcProxy', server, +proxyConfig.path);
 
-    let retries = 0
-    let wait = 1000
-
-    server.on('error', (err) => {
-      if (++retries < 10) {
-        setTimeout(() => listen(server), wait *= 2)
-      } else {
-        console.error('GrpcProxy server error', err)
-      }
-    })
-
-    server.on('request', onRequest)
-
-    function listen (server: http2.Http2Server) {
-      server.listen(proxyConfig.path, () => {
-        const msg = isForwardProxy ? '' : `, target host ${proxyConfig.hostname}`
-        console.log(`Listening on gRPC port ${proxyConfig.path} ${msg}`)
-      })
-    }
+    server.on('request', onRequest);
 
     async function onRequest (clientReq: Http2ServerRequest, clientRes: Http2ServerResponse) {
       // eslint-disable-next-line node/no-deprecated-api
-      const reqUrl = url.parse(clientReq.url ? clientReq.url : '')
+      const reqUrl = url.parse(clientReq.url ? clientReq.url : '');
 
-      if (debug) console.log('request URL', reqUrl)
+      if (debug) console.log('request URL', reqUrl);
 
-      const sequenceNumber = ++Global.nextSequenceNumber
-      const remoteAddress = clientReq.socket.remoteAddress
+      const sequenceNumber = ++Global.nextSequenceNumber;
+      const remoteAddress = clientReq.socket.remoteAddress;
       const httpMessage = new HttpMessage(
         proxyConfig,
         sequenceNumber,
@@ -84,149 +68,151 @@ export default class GrpcProxy {
         clientReq.method!,
         clientReq.url!,
         clientReq.headers
-      )
+      );
 
-      const requestBodyPromise = getReqBody(clientReq)
+      const requestBodyPromise = getReqBody(clientReq);
 
-      httpMessage.emitMessageToBrowser('') // No request body received yet
-      proxyRequest(proxyConfig!, requestBodyPromise)
+      httpMessage.emitMessageToBrowser(''); // No request body received yet
+      proxyRequest(proxyConfig!, requestBodyPromise);
 
       function proxyRequest (proxyConfig: ProxyConfig, requestBodyPromise: Promise<string | {}>) {
         clientReq.on('error', function (error) {
-          console.error(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2))
-        })
+          console.error(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2));
+        });
 
-        const headers = clientReq.headers
-        let authority = proxyConfig.hostname
-        if (proxyConfig.port) authority += ':' + proxyConfig.port
-        headers[http2.constants.HTTP2_HEADER_AUTHORITY] = authority
+        const headers = clientReq.headers;
+        let authority = proxyConfig.hostname;
+        if (proxyConfig.port) authority += ':' + proxyConfig.port;
+        headers[http2.constants.HTTP2_HEADER_AUTHORITY] = authority;
 
         let { protocol, hostname, port } = isForwardProxy
           ? reqUrl
-          : proxyConfig
+          : proxyConfig;
 
         if (!isForwardProxy) {
-          protocol = proxyConfig.isSecure ? 'https:' : 'http:'
+          protocol = proxyConfig.isSecure ? 'https:' : 'http:';
         }
 
         if (port === undefined) {
-          port = protocol === 'https:' ? 443 : 80
+          port = protocol === 'https:' ? 443 : 80;
         }
 
         const proxyClient = http2.connect(
           `${protocol}//${hostname}:${port}`,
           { settings }
-        )
+        );
 
         proxyClient.on('error', async (err) => {
-          const requestBody = await requestBodyPromise
-          httpMessage.emitMessageToBrowser(requestBody, 404, {}, { err, 'allproxy-config': proxyConfig })
-        })
+          const requestBody = await requestBodyPromise;
+          httpMessage.emitMessageToBrowser(requestBody, 404, {}, { err, 'allproxy-config': proxyConfig });
+        });
 
-        const chunks: Buffer[] = []
-        let trailers: {[key:string]: any} = {}
-        const proxyStream = proxyClient.request(headers)
-        let needToSendTrailers = false
+        const chunks: Buffer[] = [];
+        let trailers: {[key:string]: any} = {};
+        const proxyStream = proxyClient.request(headers);
+        let needToSendTrailers = false;
 
         proxyStream.on('trailers', (headers, _flags) => {
-          if (debug) console.log('trailers', headers)
-          clientRes.addTrailers(headers)
-          trailers = headers
-        })
+          if (debug) console.log('trailers', headers);
+          clientRes.addTrailers(headers);
+          trailers = headers;
+        });
 
         proxyStream.on('response', (headers, flags) => {
-          if (debug) console.log('on response', clientReq.url, headers, 'flags:', flags)
+          if (debug) console.log('on response', clientReq.url, headers, 'flags:', flags);
           if (headers['grpc-status']) {
-            trailers['grpc-status'] = headers['grpc-status']
-            trailers['grpc-message'] = headers['grpc-message']
-            headers['grpc-status'] = headers['grpc-message'] = undefined
-            needToSendTrailers = true
+            trailers['grpc-status'] = headers['grpc-status'];
+            trailers['grpc-message'] = headers['grpc-message'];
+            headers['grpc-status'] = headers['grpc-message'] = undefined;
+            needToSendTrailers = true;
           }
-          clientRes.stream.respond(headers, { waitForTrailers: true })
+          clientRes.stream.respond(headers, { waitForTrailers: true });
           // proxyStream.pipe(clientRes, {
           //   end: true
           // })
           proxyStream.on('data', function (chunk: Buffer) {
-            clientRes.write(chunk)
-            chunks.push(chunk)
-          })
+            clientRes.write(chunk);
+            chunks.push(chunk);
+          });
 
           proxyStream.on('end', async () => {
-            if (debug) console.log('end of response received')
+            if (debug) console.log('end of response received');
             if (needToSendTrailers) {
-              clientRes.addTrailers(trailers)
+              clientRes.addTrailers(trailers);
             }
-            clientRes.end()
-            proxyClient.close()
+            clientRes.end();
+            proxyClient.close();
 
-            const requestBody = await requestBodyPromise
+            const requestBody = await requestBodyPromise;
 
             // chunks.push(headers)
-            const resBody = getResBody(chunks)
+            const resBody = getResBody(headers, chunks);
             const allHeaders = {
               ...headers,
               ...trailers
-            }
-            httpMessage.emitMessageToBrowser(requestBody, headers[':status'], allHeaders, resBody)
-          })
-        })
+            };
+            httpMessage.emitMessageToBrowser(requestBody, headers[':status'], allHeaders, resBody);
+          });
+        });
 
         // Forward the client request
         clientReq.pipe(proxyStream, {
           end: true
-        })
+        });
       }
 
       function getReqBody (clientReq: Http2ServerRequest): Promise<string | {}> {
         return new Promise<string | {}>(resolve => {
           // eslint-disable-next-line no-unreachable
-          let requestBody: string | {} = ''
-          let rawData = ''
+          let requestBody: string | {} = '';
+          let rawData = '';
           clientReq.on('data', function (chunk) {
-            rawData += chunk
-          })
+            rawData += chunk;
+          });
           // eslint-disable-next-line no-unreachable
           clientReq.on('end', async function () {
             try {
-              requestBody = JSON.parse(rawData)
+              requestBody = JSON.parse(rawData);
             } catch (e) {
-              const contentType = clientReq.headers['content-type']
+              const contentType = clientReq.headers['content-type'];
               if (contentType && contentType.indexOf('application/x-www-form-urlencoded') !== -1) {
-                requestBody = querystring.parse(rawData)
+                requestBody = querystring.parse(rawData);
               } else {
-                requestBody = rawData
+                requestBody = rawData;
               }
             }
             if (proxyConfig.protocol === 'grpc:') {
-              requestBody = HexFormatter.format(Buffer.from(requestBody as string, 'utf-8'))
+              requestBody = HexFormatter.format(Buffer.from(requestBody as string, 'utf-8'));
             }
-            resolve(requestBody)
-          })
-        })
+            resolve(requestBody);
+          });
+        });
       }
 
-      function getResBody (chunks: Buffer[]): object | string {
-        if (chunks.length === 0) return ''
+      function getResBody (headers: {}, chunks: Buffer[]): object | string {
+        if (chunks.length === 0) return '';
         const resBuffer = chunks.reduce(
           (prevChunk, chunk) => Buffer.concat([prevChunk, chunk], prevChunk.length + chunk.length)
-        )
-        const resString = resBuffer.toString()
-        let resBody = ''
+        );
+        const resString = decompressResponse(headers, resBuffer).toString();
+        let resBody = '';
         try {
-          resBody = JSON.parse(resString) // assume JSON
+          resBody = JSON.parse(resString); // assume JSON
         } catch (e) {
-          resBody = resString
+          resBody = resString;
         }
         // gRPC is binary data
         if (proxyConfig.protocol === 'grpc:') {
-          resBody = HexFormatter.format(Buffer.from(resBody, 'utf-8'))
+          resBody = HexFormatter.format(Buffer.from(resBody, 'utf-8'));
         }
-        return resBody
+        return resBody;
       }
     }
   }
 
   static destructor (proxyConfig: ProxyConfig) {
-    if (proxyConfig._server) proxyConfig._server.close()
+    if (proxyConfig._server) {
+      console.log('GrpcProxy close port ', proxyConfig.path);
+    }
   }
 }

--- a/server/src/HttpMessage.ts
+++ b/server/src/HttpMessage.ts
@@ -1,7 +1,7 @@
-import ProxyConfig from '../../common/ProxyConfig'
-import { MessageType, NO_RESPONSE } from '../../common/Message'
-import SocketMessage from './SocketMessage'
-import Global from './Global'
+import ProxyConfig from '../../common/ProxyConfig';
+import { MessageType, NO_RESPONSE } from '../../common/Message';
+import SocketMessage from './SocketMessage';
+import Global from './Global';
 
 export default class HttpMessage {
   private emitCount = 0;
@@ -21,13 +21,13 @@ export default class HttpMessage {
     url: string,
     reqHeaders: {}
   ) {
-    this.startTime = Date.now()
-    this.proxyConfig = proxyConfig
-    this.sequenceNumber = sequenceNumber
-    this.remoteAddress = remoteAddress
-    this.method = method
-    this.url = url
-    this.reqHeaders = reqHeaders
+    this.startTime = Date.now();
+    this.proxyConfig = proxyConfig;
+    this.sequenceNumber = sequenceNumber;
+    this.remoteAddress = remoteAddress;
+    this.method = method;
+    this.url = url;
+    this.reqHeaders = reqHeaders;
   }
 
   public async emitMessageToBrowser (
@@ -36,9 +36,9 @@ export default class HttpMessage {
     resHeaders = {},
     resBody: string | object = NO_RESPONSE
   ) {
-    const reqBodyJson = typeof reqBody === 'object' ? reqBody : this.toJSON(reqBody)
-    const resBodyJson = resBody === NO_RESPONSE || typeof resBody === 'object' ? resBody : this.toJSON(resBody)
-    const host = this.proxyConfig ? this.getHostPort(this.proxyConfig) : 'Unknown'
+    const reqBodyJson = typeof reqBody === 'object' ? reqBody : this.toJSON(reqBody);
+    const resBodyJson = resBody === NO_RESPONSE || typeof resBody === 'object' ? resBody : this.toJSON(resBody);
+    const host = this.proxyConfig ? this.getHostPort(this.proxyConfig) : 'Unknown';
 
     const message = await SocketMessage.buildRequest(
       Date.now(),
@@ -52,9 +52,9 @@ export default class HttpMessage {
       host, // server host
       this.proxyConfig ? this.proxyConfig.path : '',
       Date.now() - this.startTime
-    )
+    );
 
-    SocketMessage.appendResponse(message, resHeaders, resBodyJson, resStatus, Date.now() - this.startTime)
+    SocketMessage.appendResponse(message, resHeaders, resBodyJson, resStatus, Date.now() - this.startTime);
 
     Global.socketIoManager.emitMessageToBrowser(
       resBody === NO_RESPONSE
@@ -64,56 +64,56 @@ export default class HttpMessage {
           : MessageType.RESPONSE,
       message,
       this.proxyConfig
-    )
-    ++this.emitCount
+    );
+    ++this.emitCount;
   }
 
   private toJSON (s: string): object | string {
     try {
-      return JSON.parse(s)
+      return JSON.parse(s);
     } catch (e) {
-      return s
+      return s;
     }
   }
 
   private getHostPort (proxyConfig: ProxyConfig) {
-    let host = proxyConfig.hostname
-    if (proxyConfig.port) host += ':' + proxyConfig.port
-    return host
+    let host = proxyConfig.hostname;
+    if (proxyConfig.port) host += ':' + proxyConfig.port;
+    return host;
   }
 
   private getHttpEndpoint = (method: string, url: string, requestBody: string | {}): string => {
-    let endpoint = url.split('?')[0]
-    const tokens = endpoint?.split('/')
-    endpoint = tokens ? tokens[tokens.length - 1] : ''
+    let endpoint = url.split('?')[0];
+    const tokens = endpoint?.split('/');
+    endpoint = tokens ? tokens[tokens.length - 1] : '';
     if (!isNaN(+endpoint) && tokens && tokens.length > 1) {
-      endpoint = tokens[tokens.length - 2] + '/' + tokens[tokens.length - 1]
+      endpoint = tokens[tokens.length - 2] + '/' + tokens[tokens.length - 1];
     }
 
     if (method !== 'OPTIONS' &&
           (url.endsWith('/graphql') || url.endsWith('/graphql-public'))) {
-      endpoint = ''
+      endpoint = '';
       if (typeof requestBody === 'object') {
         if (Array.isArray(requestBody)) {
           requestBody.forEach((entry) => {
             if (entry.operationName) {
-              if (endpoint!.length > 0) endpoint += ','
-              endpoint += ' ' + entry.operationName
+              if (endpoint!.length > 0) endpoint += ',';
+              endpoint += ' ' + entry.operationName;
             }
-          })
+          });
         } else {
           for (const key in requestBody) {
             if (key === 'operationName') {
-              if (endpoint!.length > 0) endpoint += ','
-              endpoint += ' ' + (requestBody as {[key:string]: string})[key]
+              if (endpoint!.length > 0) endpoint += ',';
+              endpoint += ' ' + (requestBody as {[key:string]: string})[key];
             }
           }
         }
       }
-      const tag = url.endsWith('/graphql-public') ? 'GQLP' : 'GQL'
-      endpoint = ' ' + tag + endpoint
+      const tag = url.endsWith('/graphql-public') ? 'GQLP' : 'GQL';
+      endpoint = ' ' + tag + endpoint;
     }
-    if ('/' + endpoint === url) endpoint = ''
-    return endpoint
+    if ('/' + endpoint === url) endpoint = '';
+    return endpoint;
   }
 }

--- a/server/src/HttpProxy.ts
+++ b/server/src/HttpProxy.ts
@@ -1,12 +1,12 @@
-import url from 'url'
-import http, { IncomingMessage } from 'http'
-import https from 'https'
-import Global from './Global'
-import ProxyConfig, { ConfigProtocol } from '../../common/ProxyConfig'
-import HttpMessage from './HttpMessage'
-import querystring from 'querystring'
-import AllProxyApp from './AllProxyApp'
-const decompressResponse = require('decompress-response')
+import url from 'url';
+import http, { IncomingMessage } from 'http';
+import https from 'https';
+import Global from './Global';
+import ProxyConfig, { ConfigProtocol } from '../../common/ProxyConfig';
+import HttpMessage from './HttpMessage';
+import querystring from 'querystring';
+import AllProxyApp from './AllProxyApp';
+const decompressResponse = require('decompress-response');
 
 /**
  * Important: This module must remain at the project root to properly set the document root for the index.html.
@@ -14,28 +14,29 @@ const decompressResponse = require('decompress-response')
 export default class HttpProxy {
   async onRequest (clientReq: IncomingMessage, clientRes: http.ServerResponse) {
     // eslint-disable-next-line node/no-deprecated-api
-    const reqUrl = url.parse(clientReq.url ? clientReq.url : '')
+    const reqUrl = url.parse(clientReq.url ? clientReq.url : '');
 
     // Request is from AllProxy app?
     if (AllProxyApp(clientRes, reqUrl)) {
-      return
+      return;
     }
 
-    const sequenceNumber = ++Global.nextSequenceNumber
-    const remoteAddress = clientReq.socket.remoteAddress
+    const sequenceNumber = ++Global.nextSequenceNumber;
+    const remoteAddress = clientReq.socket.remoteAddress;
 
     // Find matching proxy configuration
-    const clientHostName = await Global.resolveIp(clientReq.socket.remoteAddress)
-    let proxyConfig = Global.socketIoManager.findProxyConfigMatchingURL('http:', clientHostName, reqUrl)
+    const clientHostName = await Global.resolveIp(clientReq.socket.remoteAddress);
+    const proxyType = reqUrl.protocol ? 'forward' : 'reverse';
+    let proxyConfig = Global.socketIoManager.findProxyConfigMatchingURL('http:', clientHostName, reqUrl, proxyType);
     // Always proxy forward proxy requests
     if (proxyConfig === undefined && reqUrl.protocol !== null) {
-      proxyConfig = new ProxyConfig()
-      proxyConfig.path = reqUrl.pathname!
-      proxyConfig.protocol = reqUrl.protocol as ConfigProtocol
-      proxyConfig.hostname = reqUrl.hostname!
+      proxyConfig = new ProxyConfig();
+      proxyConfig.path = reqUrl.pathname!;
+      proxyConfig.protocol = reqUrl.protocol as ConfigProtocol;
+      proxyConfig.hostname = reqUrl.hostname!;
       proxyConfig.port = reqUrl.port === null
         ? reqUrl.protocol === 'http:' ? 80 : 443
-        : +reqUrl.port
+        : +reqUrl.port;
     }
 
     const httpMessage = new HttpMessage(
@@ -45,50 +46,50 @@ export default class HttpProxy {
         clientReq.method!,
         clientReq.url!,
         clientReq.headers
-    )
+    );
 
-    const requestBodyPromise = getReqBody(clientReq)
+    const requestBodyPromise = getReqBody(clientReq);
 
     if (proxyConfig === undefined) {
-      const requestBody = await requestBodyPromise
-      const error = 'No matching proxy configuration found for ' + reqUrl.pathname
+      const requestBody = await requestBodyPromise;
+      const error = 'No matching proxy configuration found for ' + reqUrl.pathname;
       if (reqUrl.pathname === '/') {
-        clientRes.writeHead(302, { Location: reqUrl.href + 'allproxy' })
-        clientRes.end()
+        clientRes.writeHead(302, { Location: reqUrl.href + 'allproxy' });
+        clientRes.end();
       } else {
-        httpMessage.emitMessageToBrowser(requestBody, 404, {}, { error })
+        httpMessage.emitMessageToBrowser(requestBody, 404, {}, { error });
       }
     } else {
-      httpMessage.emitMessageToBrowser('') // No request body received yet
-      proxyRequest(proxyConfig, requestBodyPromise)
+      httpMessage.emitMessageToBrowser(''); // No request body received yet
+      proxyRequest(proxyConfig, requestBodyPromise);
     }
 
     function proxyRequest (proxyConfig: ProxyConfig, requestBodyPromise: Promise<string | {}>) {
       clientReq.on('close', function () {
         // sendErrorResponse(499, "Client closed connection", undefined, proxyConfig.path);
-      })
+      });
 
       clientReq.on('error', function (error) {
-        console.error(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2))
-      })
+        console.error(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2));
+      });
 
-      let method = clientReq.method
+      let method = clientReq.method;
 
       // GET request received with body?
       if (clientReq.method === 'GET' &&
           clientReq.headers['content-length'] && +clientReq.headers['content-length'] > 0) {
-        method = 'POST' // forward request as POST
+        method = 'POST'; // forward request as POST
       }
 
-      const headers = clientReq.headers
-      headers.host = proxyConfig.hostname
-      if (proxyConfig.port) headers.host += ':' + proxyConfig.port
+      const headers = clientReq.headers;
+      headers.host = proxyConfig.hostname;
+      if (proxyConfig.port) headers.host += ':' + proxyConfig.port;
 
-      let { protocol, hostname, port } = proxyConfig.protocol === 'browser:' || proxyConfig.protocol === 'log:'
+      let { protocol, hostname, port } = proxyConfig.protocol === 'browser:'
         ? reqUrl
-        : proxyConfig
+        : proxyConfig;
       if (port === undefined) {
-        port = proxyConfig.protocol === 'https:' ? 443 : 80
+        port = proxyConfig.protocol === 'https:' ? 443 : 80;
       }
 
       const options = {
@@ -98,101 +99,98 @@ export default class HttpProxy {
         path: clientReq.url,
         method,
         headers
-      }
+      };
 
-      let proxy
+      let proxy;
       if (options.protocol === 'https:') {
-        // options.cert: fs.readFileSync('/home/davidchr/imlTrust.pem');
-        // options.headers.Authorization = 'Basic ' + new Buffer.from('elastic:imliml').toString('base64'); // hardcoded authentication
-        proxy = https.request(options, handleResponse)
+        proxy = https.request(options, handleResponse);
       } else {
-        proxy = http.request(options, handleResponse)
+        proxy = http.request(options, handleResponse);
       }
 
       async function handleResponse (proxyRes: http.IncomingMessage) {
-        const requestBody = await requestBodyPromise
+        const requestBody = await requestBodyPromise;
         if (
           typeof requestBody === 'object' ||
           (typeof requestBody === 'string' && requestBody.length > 0)
         ) {
-          httpMessage.emitMessageToBrowser(requestBody)
+          httpMessage.emitMessageToBrowser(requestBody);
         }
 
         /**
          * Forward the response back to the client
          */
-        clientRes.writeHead((proxyRes as any).statusCode, proxyRes.headers)
+        clientRes.writeHead((proxyRes as any).statusCode, proxyRes.headers);
         proxyRes.pipe(clientRes, {
           end: true
-        })
+        });
 
-        const resBody = await getResBody(proxyRes)
-        httpMessage.emitMessageToBrowser(requestBody, proxyRes.statusCode, proxyRes.headers, resBody)
+        const resBody = await getResBody(proxyRes);
+        httpMessage.emitMessageToBrowser(requestBody, proxyRes.statusCode, proxyRes.headers, resBody);
       }
 
       proxy.on('error', async function (error) {
-        console.error(sequenceNumber, 'Proxy connect error', JSON.stringify(error, null, 2), 'config:', proxyConfig)
-        const requestBody = await requestBodyPromise
-        httpMessage.emitMessageToBrowser(requestBody, 404, {}, { error, 'allproxy-config': proxyConfig })
-      })
+        console.error(sequenceNumber, 'Proxy connect error', JSON.stringify(error, null, 2), 'config:', proxyConfig);
+        const requestBody = await requestBodyPromise;
+        httpMessage.emitMessageToBrowser(requestBody, 404, {}, { error, 'allproxy-config': proxyConfig });
+      });
 
       clientReq.pipe(proxy, {
         end: true
-      })
+      });
     }
 
     function getReqBody (clientReq: IncomingMessage): Promise<string | {}> {
       return new Promise<string | {}>(resolve => {
-        let requestBody: string | {} = ''
-        clientReq.setEncoding('utf8')
-        let rawData = ''
+        let requestBody: string | {} = '';
+        clientReq.setEncoding('utf8');
+        let rawData = '';
         clientReq.on('data', function (chunk) {
-          rawData += chunk
-        })
+          rawData += chunk;
+        });
         clientReq.on('end', async function () {
           try {
-            requestBody = JSON.parse(rawData)
+            requestBody = JSON.parse(rawData);
           } catch (e) {
-            const contentType = clientReq.headers['content-type']
+            const contentType = clientReq.headers['content-type'];
             if (contentType && contentType.indexOf('application/x-www-form-urlencoded') !== -1) {
-              requestBody = querystring.parse(rawData)
+              requestBody = querystring.parse(rawData);
             } else {
-              requestBody = rawData
+              requestBody = rawData;
             }
           }
-          resolve(requestBody)
-        })
-      })
+          resolve(requestBody);
+        });
+      });
     }
 
     function getResBody (proxyRes: any): Promise<object | string> {
       return new Promise<string | {}>(resolve => {
         if (proxyRes.headers) {
           if (proxyRes.headers['content-encoding']) {
-            proxyRes = decompressResponse(proxyRes)
-            // delete proxyRes.headers['content-encoding'];
+            proxyRes = decompressResponse(proxyRes);
           }
 
           if (proxyRes.headers['content-type'] &&
               proxyRes.headers['content-type'].indexOf('utf-8') !== -1) {
-            proxyRes.setEncoding('utf8')
+            proxyRes.setEncoding('utf8');
           }
         }
 
-        let rawData = ''
+        let rawData = '';
         proxyRes.on('data', function (chunk: string) {
-          rawData += chunk
-        })
-        let parsedData = ''
+          rawData += chunk;
+        });
+        let parsedData = '';
         proxyRes.on('end', () => {
           try {
-            parsedData = JSON.parse(rawData) // assume JSON
+            parsedData = JSON.parse(rawData); // assume JSON
           } catch (e) {
-            parsedData = rawData
+            parsedData = rawData;
           }
-          resolve(parsedData)
-        })
-      })
+          resolve(parsedData);
+        });
+      });
     }
   }
 }

--- a/server/src/Https1Proxy.ts
+++ b/server/src/Https1Proxy.ts
@@ -1,0 +1,146 @@
+import url from 'url';
+import Global from './Global';
+import ProxyConfig, { ConfigProtocol } from '../../common/ProxyConfig';
+import Proxy from '../../node-http-mitm-proxy';
+import HttpMessage from './HttpMessage';
+import replaceResponse from './ReplaceResponse';
+import decompressResponse from './DecompressResponse';
+
+/**
+ * Important: This module must remain at the project root to properly set the document root for the index.html.
+ */
+export default class Https1Proxy {
+  onRequest (proxy: Proxy.IProxy) {
+    proxy.onRequest(async function (ctx, callback) {
+      const clientReq = ctx.clientToProxyRequest;
+      const clientRes = ctx.proxyToClientResponse;
+
+      const sequenceNumber = ++Global.nextSequenceNumber;
+      const remoteAddress = clientReq.socket.remoteAddress;
+
+      const reqHeaders = ctx.proxyToServerRequestOptions.headers;
+      const connectRequest = Object.keys((ctx as any).connectRequest).length > 0;
+      if (connectRequest) {
+        const host = reqHeaders.host;
+        clientReq.url = 'https://' + host + clientReq.url;
+      }
+
+      // eslint-disable-next-line node/no-deprecated-api
+      const reqUrl = url.parse(clientReq.url ? clientReq.url : '');
+
+      // Find matching proxy configuration
+      let proxyConfig;
+
+      const clientHostName = await Global.resolveIp(clientReq.socket.remoteAddress);
+      if (!connectRequest) {
+        proxyConfig = Global.socketIoManager.findProxyConfigMatchingURL('https:', clientHostName, reqUrl, 'reverse');
+        if (proxyConfig !== undefined) {
+          ctx.proxyToServerRequestOptions.headers.host = proxyConfig.hostname;
+          clientReq.url = 'https://' + proxyConfig.hostname + clientReq.url;
+        }
+      } else {
+        proxyConfig = Global.socketIoManager.findProxyConfigMatchingURL('https:', clientHostName, reqUrl, 'forward');
+        // Always proxy forward proxy requests
+        if (proxyConfig === undefined) {
+          proxyConfig = new ProxyConfig();
+          proxyConfig.path = reqUrl.pathname!;
+          proxyConfig.protocol = reqUrl.protocol! as ConfigProtocol;
+          proxyConfig.hostname = reqUrl.hostname!;
+          proxyConfig.port = reqUrl.port === null
+            ? reqUrl.protocol === 'http:' ? 80 : 443
+            : +reqUrl.port;
+        }
+      }
+
+      const httpMessage = new HttpMessage(
+        proxyConfig,
+        sequenceNumber,
+        remoteAddress!,
+        clientReq.method!,
+        clientReq.url!,
+        reqHeaders
+      );
+
+      if (proxyConfig === undefined) {
+        const msg = 'No matching proxy configuration found for ' + reqUrl.pathname;
+        ctx.proxyToClientResponse.end('404 ' + msg);
+        httpMessage.emitMessageToBrowser(msg);
+      } else {
+        proxyRequest();
+      }
+
+      callback();
+
+      function proxyRequest () {
+        clientReq.on('close', function () {
+
+        });
+
+        clientReq.on('error', function (error) {
+          console.log(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2));
+        });
+
+        clientRes.on('error', function (error) {
+          console.error(sequenceNumber, 'Server connection error', JSON.stringify(error, null, 2));
+          httpMessage.emitMessageToBrowser(JSON.stringify(error, null, 2));
+        });
+
+        let replaceRes: Buffer | null = null;
+        if (reqUrl.pathname) {
+          replaceRes = replaceResponse(reqUrl.pathname);
+        }
+
+        let reqChunks: string = '';
+        ctx.onRequestData(function (_ctx, chunk, callback) {
+          reqChunks += chunk.toString();
+          return callback(undefined, chunk);
+        });
+
+        ctx.onRequestEnd(function (_ctx, callback) {
+          httpMessage.emitMessageToBrowser(reqChunks);
+          return callback();
+        });
+
+        ctx.onResponse(function (ctx, callback) {
+          const resChunks: Buffer[] = [];
+          ctx.onResponseData(function (_ctx, chunk, callback) {
+            if (replaceRes) {
+              return callback();
+            } else {
+              resChunks.push(chunk);
+              return callback(undefined, chunk);
+            }
+          });
+
+          ctx.onResponseEnd(function (ctx, callback) {
+            const resHeaders = ctx.serverToProxyResponse.headers;
+            if (replaceRes) {
+              resHeaders['allproxy-replaced-response'] = 'yes';
+            }
+            const resBuffer = resChunks.reduce(
+              (prevChunk, chunk) => Buffer.concat([prevChunk, chunk], prevChunk.length + chunk.length),
+              Buffer.from('')
+            );
+            httpMessage.emitMessageToBrowser(
+              reqChunks,
+              ctx.serverToProxyResponse.statusCode,
+              resHeaders,
+              replaceRes ? replaceRes.toString() : decompressResponse(resHeaders, resBuffer).toString()
+            );
+            if (replaceRes) {
+              ctx.proxyToClientResponse.writeHead(
+                ctx.serverToProxyResponse.statusCode!,
+                undefined,
+                resHeaders
+              );
+              ctx.proxyToClientResponse.write(replaceRes);
+            }
+            return callback();
+          });
+
+          return callback();
+        });
+      }
+    });
+  }
+}

--- a/server/src/Https1Server.ts
+++ b/server/src/Https1Server.ts
@@ -1,0 +1,211 @@
+import url from 'url';
+import http, { IncomingMessage } from 'http';
+import https from 'https';
+import Global from './Global';
+import ProxyConfig from '../../common/ProxyConfig';
+import HttpMessage from './HttpMessage';
+import querystring from 'querystring';
+import listen from './Listen';
+import { AddressInfo } from 'net';
+import generateCertKey from './GenerateCertKey';
+const decompressResponse = require('decompress-response');
+
+const debug = false;
+type ProxyType = 'forward' | 'reverse';
+
+/**
+ * Important: This module must remain at the project root to properly set the document root for the index.html.
+ */
+export default class Https1Server {
+  private proxyType: ProxyType = 'forward';
+  private hostname: string;
+  private port = 0;
+  private server: https.Server | null = null;
+
+  private resolvePromise: (result: number) => void = () => 1;
+  private promise: Promise<number> = new Promise((resolve) => {
+    this.resolvePromise = resolve;
+  });
+
+  constructor (hostname: string, proxyType: ProxyType) {
+    this.proxyType = proxyType;
+    this.hostname = hostname;
+  }
+
+  destructor () {
+    this.server && this.server.close();
+  }
+
+  public async start () {
+    const certKey = await generateCertKey(this.hostname);
+    this.server = https.createServer(
+      certKey,
+      this.onRequest.bind(this)
+    );
+
+    await listen('Https1Server', this.server, 0); // assign port number
+    this.port = (this.server.address() as AddressInfo).port;
+
+    this.resolvePromise(0);
+  }
+
+  public async waitForServerToStart () {
+    await this.promise;
+  }
+
+  public getPort () {
+    return this.port;
+  }
+
+  private async onRequest (clientReq: IncomingMessage, clientRes: http.ServerResponse) {
+    clientReq.on('error', function (error) {
+      console.error(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2));
+    });
+
+    // eslint-disable-next-line node/no-deprecated-api
+    const reqUrl = url.parse(clientReq.url ? clientReq.url : '');
+
+    if (debug) console.log('request URL', reqUrl);
+
+    const clientHostName = await Global.resolveIp(clientReq.socket.remoteAddress);
+    const sequenceNumber = ++Global.nextSequenceNumber;
+    const remoteAddress = clientReq.socket.remoteAddress;
+    let proxyConfig = Global.socketIoManager.findProxyConfigMatchingURL('https:', clientHostName, reqUrl, this.proxyType);
+    // Always proxy forward proxy requests
+    if (proxyConfig === undefined && this.proxyType === 'forward') {
+      proxyConfig = new ProxyConfig();
+      proxyConfig.path = reqUrl.pathname!;
+      proxyConfig.protocol = 'https:';
+      proxyConfig.hostname = this.hostname;
+      proxyConfig.port = 443;
+      proxyConfig.isSecure = true;
+    };
+
+    const httpMessage = new HttpMessage(
+      proxyConfig,
+      sequenceNumber,
+      remoteAddress!,
+      clientReq.method!,
+      clientReq.url!,
+      clientReq.headers
+    );
+
+    if (proxyConfig === undefined) {
+      const msg = 'No matching proxy configuration found for ' + reqUrl.pathname;
+      clientRes.writeHead(404, msg);
+      clientRes.end();
+      httpMessage.emitMessageToBrowser(msg);
+    } else {
+      const requestBodyPromise = getReqBody(clientReq);
+
+      httpMessage.emitMessageToBrowser(''); // No request body received yet
+
+      this.proxyRequest(clientReq, clientRes, httpMessage, proxyConfig!, requestBodyPromise);
+    }
+
+    function getReqBody (clientReq: IncomingMessage): Promise<string | {}> {
+      return new Promise<string | {}>(resolve => {
+        // eslint-disable-next-line no-unreachable
+        let requestBody: string | {} = '';
+        let rawData = '';
+        clientReq.on('data', function (chunk) {
+          rawData += chunk;
+        });
+        // eslint-disable-next-line no-unreachable
+        clientReq.on('end', async function () {
+          try {
+            requestBody = JSON.parse(rawData);
+          } catch (e) {
+            const contentType = clientReq.headers['content-type'];
+            if (contentType && contentType.indexOf('application/x-www-form-urlencoded') !== -1) {
+              requestBody = querystring.parse(rawData);
+            } else {
+              requestBody = rawData;
+            }
+          }
+          resolve(requestBody);
+        });
+      });
+    }
+  }
+
+  private async proxyRequest (
+    clientReq: IncomingMessage,
+    clientRes: http.ServerResponse,
+    httpMessage: HttpMessage,
+    proxyConfig: ProxyConfig,
+    requestBodyPromise: Promise<string | {}>
+  ) {
+    const headers = clientReq.headers;
+    const options = {
+      protocol: 'https:',
+      hostname: this.hostname,
+      port: 443,
+      path: clientReq.url,
+      method: clientReq.method,
+      headers
+    };
+
+    const proxyReq = https.request(options, handleResponse);
+
+    async function handleResponse (proxyRes: http.IncomingMessage) {
+      const requestBody = await requestBodyPromise;
+      if (
+        typeof requestBody === 'object' ||
+        (typeof requestBody === 'string' && requestBody.length > 0)
+      ) {
+        httpMessage.emitMessageToBrowser(requestBody);
+      }
+
+      /**
+       * Forward the response back to the client
+       */
+      clientRes.writeHead((proxyRes as any).statusCode, proxyRes.headers);
+      proxyRes.pipe(clientRes, {
+        end: true
+      });
+
+      const resBody = await getResBody(proxyRes);
+      httpMessage.emitMessageToBrowser(requestBody, proxyRes.statusCode, proxyRes.headers, resBody);
+    }
+
+    proxyReq.on('error', async function (error) {
+      console.error('Proxy connect error', JSON.stringify(error, null, 2), 'config:', proxyConfig);
+      const requestBody = await requestBodyPromise;
+      httpMessage.emitMessageToBrowser(requestBody, 404, {}, { error, 'allproxy-config': proxyConfig });
+    });
+
+    clientReq.pipe(proxyReq, {
+      end: true
+    });
+  }
+}
+
+function getResBody (proxyRes: any): Promise<object | string> {
+  return new Promise<string | {}>(resolve => {
+    if (proxyRes.headers) {
+      if (proxyRes.headers['content-encoding']) {
+        proxyRes = decompressResponse(proxyRes);
+      }
+
+      if (proxyRes.headers['content-type'] &&
+          proxyRes.headers['content-type'].indexOf('utf-8') !== -1) {
+        proxyRes.setEncoding('utf8');
+      }
+    }
+
+    let rawData = '';
+    proxyRes.on('data', function (chunk: string) {
+      rawData += chunk;
+    });
+    let parsedData = '';
+    proxyRes.on('end', () => {
+      try {
+        parsedData = JSON.parse(rawData); // assume JSON
+      } catch (e) {
+        parsedData = rawData;
+      }
+      resolve(parsedData);
+    });
+  });
+}

--- a/server/src/Https2Server.ts
+++ b/server/src/Https2Server.ts
@@ -1,0 +1,212 @@
+import url from 'url';
+import http2, { Http2ServerRequest, Http2ServerResponse } from 'http2';
+import Global from './Global';
+import ProxyConfig from '../../common/ProxyConfig';
+import HttpMessage from './HttpMessage';
+import querystring from 'querystring';
+import listen from './Listen';
+import { AddressInfo } from 'net';
+import generateCertKey from './GenerateCertKey';
+import decompressResponse from './DecompressResponse';
+
+const debug = false;
+type ProxyType = 'forward' | 'reverse';
+
+/**
+ * Important: This module must remain at the project root to properly set the document root for the index.html.
+ */
+export default class Https2Server {
+  private proxyType: ProxyType = 'forward';
+  private hostname: string;
+  private port = 0;
+  private server: http2.Http2SecureServer | null = null;
+
+  private resolvePromise: (result: number) => void = () => 1;
+  private promise: Promise<number> = new Promise((resolve) => {
+    this.resolvePromise = resolve;
+  });
+
+  constructor (hostname: string, proxyType: ProxyType) {
+    this.proxyType = proxyType;
+    this.hostname = hostname;
+  }
+
+  destructor () {
+    this.server && this.server.close();
+  }
+
+  public async start () {
+    const certKey = await generateCertKey(this.hostname);
+    this.server = http2.createSecureServer(
+      {
+        allowHTTP1: true,
+        ...certKey
+      },
+      this.onRequest.bind(this)
+    );
+
+    await listen('Https2Server', this.server, 0); // assign port number
+    this.port = (this.server.address() as AddressInfo).port;
+
+    this.resolvePromise(0);
+  }
+
+  public async waitForServerToStart () {
+    await this.promise;
+  }
+
+  public getPort () {
+    return this.port;
+  }
+
+  private async onRequest (clientReq: Http2ServerRequest, clientRes: Http2ServerResponse) {
+    clientReq.on('error', function (error) {
+      console.error(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2));
+    });
+
+    // eslint-disable-next-line node/no-deprecated-api
+    const reqUrl = url.parse(clientReq.url ? clientReq.url : '');
+
+    if (debug) console.log('request URL', reqUrl);
+
+    const clientHostName = await Global.resolveIp(clientReq.socket.remoteAddress);
+    const sequenceNumber = ++Global.nextSequenceNumber;
+    const remoteAddress = clientReq.socket.remoteAddress;
+    let proxyConfig = Global.socketIoManager.findProxyConfigMatchingURL('https:', clientHostName, reqUrl, this.proxyType);
+    // Always proxy forward proxy requests
+    if (proxyConfig === undefined && this.proxyType === 'forward') {
+      proxyConfig = new ProxyConfig();
+      proxyConfig.path = reqUrl.pathname!;
+      proxyConfig.protocol = 'https:';
+      proxyConfig.hostname = this.hostname;
+      proxyConfig.port = 443;
+      proxyConfig.isSecure = true;
+    };
+
+    const httpMessage = new HttpMessage(
+      proxyConfig,
+      sequenceNumber,
+      remoteAddress!,
+      clientReq.method!,
+      clientReq.url!,
+      clientReq.headers
+    );
+
+    if (proxyConfig === undefined) {
+      const msg = 'No matching proxy configuration found for ' + reqUrl.pathname;
+      clientRes.writeHead(404, msg);
+      clientRes.end();
+      httpMessage.emitMessageToBrowser(msg);
+    } else {
+      const requestBodyPromise = getReqBody(clientReq);
+
+      httpMessage.emitMessageToBrowser(''); // No request body received yet
+
+      this.proxyRequest(clientReq, clientRes, httpMessage, proxyConfig!, requestBodyPromise);
+    }
+
+    function getReqBody (clientReq: Http2ServerRequest): Promise<string | {}> {
+      return new Promise<string | {}>(resolve => {
+        // eslint-disable-next-line no-unreachable
+        let requestBody: string | {} = '';
+        let rawData = '';
+        clientReq.on('data', function (chunk) {
+          rawData += chunk;
+        });
+        // eslint-disable-next-line no-unreachable
+        clientReq.on('end', async function () {
+          try {
+            requestBody = JSON.parse(rawData);
+          } catch (e) {
+            const contentType = clientReq.headers['content-type'];
+            if (contentType && contentType.indexOf('application/x-www-form-urlencoded') !== -1) {
+              requestBody = querystring.parse(rawData);
+            } else {
+              requestBody = rawData;
+            }
+          }
+          resolve(requestBody);
+        });
+      });
+    }
+  }
+
+  private async proxyRequest (
+    clientReq: Http2ServerRequest,
+    clientRes: Http2ServerResponse,
+    httpMessage: HttpMessage,
+    proxyConfig: ProxyConfig,
+    requestBodyPromise: Promise<string | {}>
+  ) {
+    const headers = clientReq.headers;
+    const authority = this.hostname + ':443';
+    headers[http2.constants.HTTP2_HEADER_AUTHORITY] = authority;
+    delete headers.host;
+    delete headers.connection;
+    delete headers.upgrade;
+
+    const url = `https://${authority}`;
+    const clientHttp2Session = http2.connect(url);
+
+    clientHttp2Session.on('error', async (err) => {
+      const requestBody = await requestBodyPromise;
+      httpMessage.emitMessageToBrowser(requestBody, 404, {}, { err, 'allproxy-config': proxyConfig });
+    });
+
+    const chunks: Buffer[] = [];
+    let proxyStream: http2.ClientHttp2Stream;
+    try {
+      proxyStream = clientHttp2Session.request(headers);
+    } catch (e) {
+      console.log(headers);
+      throw e;
+    }
+
+    proxyStream.on('response', (headers, flags) => {
+      if (debug) console.log('on response', clientReq.url, headers, 'flags:', flags);
+      if (clientRes.stream) {
+        clientRes.stream.respond(headers, { waitForTrailers: true });
+      }
+      proxyStream.on('data', function (chunk: Buffer) {
+        clientRes.write(chunk);
+        chunks.push(chunk);
+      });
+
+      proxyStream.on('end', async () => {
+        if (debug) console.log('end of response received');
+        clientRes.end();
+        if (clientHttp2Session) {
+          clientHttp2Session.close();
+        }
+
+        const requestBody = await requestBodyPromise;
+
+        // chunks.push(headers)
+        const resBody = getResBody(headers, chunks);
+        httpMessage.emitMessageToBrowser(requestBody, headers[':status'], headers, resBody);
+      });
+    });
+
+    // Forward the client request
+    clientReq.pipe(proxyStream, {
+      end: true
+    });
+  }
+}
+
+function getResBody (headers: {}, chunks: Buffer[]): object | string {
+  if (chunks.length === 0) return '';
+  let resBuffer = chunks.reduce(
+    (prevChunk, chunk) => Buffer.concat([prevChunk, chunk], prevChunk.length + chunk.length)
+  );
+  resBuffer = decompressResponse(headers, resBuffer);
+  const resString = resBuffer.toString();
+  let resBody = '';
+  try {
+    resBody = JSON.parse(resString); // assume JSON
+  } catch (e) {
+    resBody = resString;
+  }
+
+  return resBody;
+}

--- a/server/src/Listen.ts
+++ b/server/src/Listen.ts
@@ -1,0 +1,32 @@
+export default async function listen (
+  serverName: string,
+  server: any,
+  port: number,
+  host?: string
+): Promise<number> {
+  let retries = 0;
+  let backOff = 1000;
+
+  return new Promise((resolve) => {
+    server.on('error', onError);
+
+    _listen();
+
+    function _listen () {
+      server.listen(port, host, 511, () => {
+        port = server.address().port;
+        console.log(`Listening on ${serverName} port ${port}`);
+        resolve(port);
+      });
+    }
+
+    // Retry the listen with exponential back off
+    function onError (err: any) {
+      if (++retries < 10) {
+        setTimeout(() => _listen(), backOff *= 2);
+      } else {
+        console.error(`${serverName} listen error on port ${port}`, err);
+      }
+    }
+  });
+}

--- a/server/src/LogProxy.ts
+++ b/server/src/LogProxy.ts
@@ -1,8 +1,8 @@
-import { spawn } from 'child_process'
-import SocketIoMessage from './SocketMessage'
-import Global from './Global'
-import ProxyConfig from '../../common/ProxyConfig'
-import { MessageType } from '../../common/Message'
+import { spawn } from 'child_process';
+import SocketIoMessage from './SocketMessage';
+import Global from './Global';
+import ProxyConfig from '../../common/ProxyConfig';
+import { MessageType } from '../../common/Message';
 
 export default class LogProxy {
   proxyConfig: ProxyConfig;
@@ -10,62 +10,62 @@ export default class LogProxy {
   retry = true;
 
   constructor (proxyConfig: ProxyConfig) {
-    this.proxyConfig = proxyConfig
-    this.command = proxyConfig.path
-    this.start()
+    this.proxyConfig = proxyConfig;
+    this.command = proxyConfig.path;
+    this.start();
   }
 
   static destructor (proxyConfig: ProxyConfig) {
     if (proxyConfig.logProxyProcess) {
       try {
-        const proc = proxyConfig.logProxyProcess
-        proc.stdout.removeAllListeners()
-        proc.stderr.removeAllListeners()
-        proc.removeAllListeners()
-        proc.kill('SIGINT')
+        const proc = proxyConfig.logProxyProcess;
+        proc.stdout.removeAllListeners();
+        proc.stderr.removeAllListeners();
+        proc.removeAllListeners();
+        proc.kill('SIGINT');
       } catch (e) {
-        console.error(e)
+        console.error(e);
       }
     }
   }
 
   start () {
-    LogProxy.destructor(this.proxyConfig)
-    this.retry = true
-    const tokens = this.command.split(' ')
-    const proc = spawn(tokens[0], tokens.slice(1))
+    LogProxy.destructor(this.proxyConfig);
+    this.retry = true;
+    const tokens = this.command.split(' ');
+    const proc = spawn(tokens[0], tokens.slice(1));
     // ('start', proc.pid);
-    this.proxyConfig.logProxyProcess = proc // save so we can kill process
-    const startTime = Date.now()
+    this.proxyConfig.logProxyProcess = proc; // save so we can kill process
+    const startTime = Date.now();
 
     proc.stdout.on('data', data => {
       if (warmUpCompleted()) {
-        this.sendToBrowser('stdout', data)
+        this.sendToBrowser('stdout', data);
       }
-    })
+    });
 
     proc.stderr.on('data', data => {
       if (warmUpCompleted()) {
-        this.sendToBrowser('stderr', data)
+        this.sendToBrowser('stderr', data);
       }
-    })
+    });
 
     proc.on('error', error => {
-      console.error(`error: ${error} - ${this.command}`)
-    })
+      console.error(`error: ${error} - ${this.command}`);
+    });
 
     proc.on('exit', _rc => {
-      proc.stdout.removeAllListeners()
-      proc.stderr.removeAllListeners()
-      proc.removeAllListeners()
+      proc.stdout.removeAllListeners();
+      proc.stderr.removeAllListeners();
+      proc.removeAllListeners();
       if (this.retry) {
-        setTimeout(() => this.start(), 10000) // Retry in 10 seconds
-        this.retry = false
+        setTimeout(() => this.start(), 10000); // Retry in 10 seconds
+        this.retry = false;
       }
-    })
+    });
 
     function warmUpCompleted () {
-      return Date.now() > startTime + 3000
+      return Date.now() > startTime + 3000;
     }
   }
 
@@ -79,27 +79,27 @@ export default class LogProxy {
 
   async sendToBrowser (streamName: string, data: any) {
     if (this.timerHandle) {
-      clearInterval(this.timerHandle)
+      clearInterval(this.timerHandle);
     }
 
     if (this.streamName.length === 0) {
-      this.streamName = streamName
+      this.streamName = streamName;
     }
 
-    this.buffer += data
+    this.buffer += data;
     if (++this.recordCount < this.RECORD_LIMIT && streamName === this.streamName) {
       this.timerHandle = setInterval(
         () => {
-          this.recordCount = this.RECORD_LIMIT
-          this.sendToBrowser(this.streamName, '')
+          this.recordCount = this.RECORD_LIMIT;
+          this.sendToBrowser(this.streamName, '');
         },
         this.TIMEOUT
-      )
-      return
+      );
+      return;
     }
 
-    const seqNo = ++Global.nextSequenceNumber
-    const commandTokens = this.command.split(' ')
+    const seqNo = ++Global.nextSequenceNumber;
+    const commandTokens = this.command.split(' ');
     const message = await SocketIoMessage.buildRequest(
       Date.now(),
       seqNo,
@@ -112,12 +112,12 @@ export default class LogProxy {
       streamName, // serverHost
       '', // path
       0
-    )
-    SocketIoMessage.appendResponse(message, {}, this.buffer.toString(), 0, 0)
-    message.protocol = 'log:'
-    Global.socketIoManager.emitMessageToBrowser(MessageType.REQUEST_AND_RESPONSE, message, this.proxyConfig)
+    );
+    SocketIoMessage.appendResponse(message, {}, this.buffer.toString(), 0, 0);
+    message.protocol = 'log:';
+    Global.socketIoManager.emitMessageToBrowser(MessageType.REQUEST_AND_RESPONSE, message, this.proxyConfig);
 
-    this.buffer = ''
-    this.recordCount = 0
+    this.buffer = '';
+    this.recordCount = 0;
   }
 }

--- a/server/src/Paths.ts
+++ b/server/src/Paths.ts
@@ -1,5 +1,5 @@
-import fs from 'fs'
-import path from 'path'
+import fs from 'fs';
+import path from 'path';
 
 export default class Paths {
   private static baseDir = process.env.NODE_ENV === 'production'
@@ -11,38 +11,38 @@ export default class Paths {
     : Paths.baseDir
 
   public static configJson (): string {
-    return Paths.platform(`${Paths.dataDir}config.json`)
+    return Paths.platform(`${Paths.dataDir}config.json`);
   }
 
   public static replaceResponsesDir (): string {
-    return Paths.platform(`${Paths.dataDir}replace-responses/`)
+    return Paths.platform(`${Paths.dataDir}replace-responses/`);
   }
 
   public static sslCaDir (): string {
-    return Paths.platform(`${Paths.dataDir}.http-mitm-proxy`)
+    return Paths.platform(`${Paths.dataDir}.http-mitm-proxy`);
   }
 
   public static makeCaPemSymLink () {
-    const target = Paths.platform(Paths.platform('.http-mitm-proxy/certs/ca.pem'))
-    const path = Paths.platform(Paths.dataDir + 'ca.pem')
+    const target = Paths.platform(Paths.platform('.http-mitm-proxy/certs/ca.pem'));
+    const path = Paths.platform(Paths.dataDir + 'ca.pem');
     try {
-      fs.symlinkSync(target, path)
+      fs.symlinkSync(target, path);
     } catch (e) {} // Already exists
   }
 
   public static serverKey (): string {
-    return Paths.platform(`${Paths.baseDir}private/keys/server.key`)
+    return Paths.platform(`${Paths.baseDir}private/keys/server.key`);
   }
 
   public static serverCrt (): string {
-    return Paths.platform(`${Paths.baseDir}private/keys/server.crt`)
+    return Paths.platform(`${Paths.baseDir}private/keys/server.crt`);
   }
 
   public static clientDir (): string {
-    return Paths.platform(`${Paths.baseDir}client`)
+    return Paths.platform(`${Paths.baseDir}client`);
   }
 
   private static platform (dir: string): string {
-    return dir.replace(/\//g, path.sep)
+    return dir.replace(/\//g, path.sep);
   }
 }

--- a/server/src/Ping.ts
+++ b/server/src/Ping.ts
@@ -1,21 +1,21 @@
-import { spawn } from 'child_process'
+import { spawn } from 'child_process';
 
 export default class Ping {
   public static host (hostName: string): Promise<boolean> {
     return new Promise((resolve) => {
-      const proc = spawn('ping', ['-c', '1', hostName])
+      const proc = spawn('ping', ['-c', '1', hostName]);
 
       proc.stdout.on('data', _data => {
-        resolve(true)
-      })
+        resolve(true);
+      });
 
       proc.stderr.on('data', _data => {
-        resolve(false)
-      })
+        resolve(false);
+      });
 
       proc.on('error', _error => {
-        resolve(false)
-      })
-    })
+        resolve(false);
+      });
+    });
   }
 }

--- a/server/src/ReplaceResponse.ts
+++ b/server/src/ReplaceResponse.ts
@@ -1,38 +1,38 @@
-import fs from 'fs'
-import Paths from './Paths'
-import { exec } from 'child_process'
+import fs from 'fs';
+import Paths from './Paths';
+import { exec } from 'child_process';
 
-const files: {[key:string]:string} = {}
-let filesRead = false
+const files: {[key:string]:string} = {};
+let filesRead = false;
 
 export default function replaceResponse (url: string): Buffer | null {
   if (!filesRead) {
-    filesRead = true
-    const command = `find ${Paths.replaceResponsesDir()} -type f`
+    filesRead = true;
+    const command = `find ${Paths.replaceResponsesDir()} -type f`;
     // console.log('replaceResponse', command)
     exec(command, (error, stdout, stderr) => {
       if (error) {
-        console.log(error)
+        console.log(error);
       }
       if (stderr) {
-        console.log(stderr)
+        console.log(stderr);
       }
       if (stdout) {
         for (const file of stdout.split('\n')) {
           if (file.length > 0) {
-            const url = file.substr(Paths.replaceResponsesDir().length - 1)
-            console.log('Found file in replace-responses directory for url:', url)
-            files[url] = file
+            const url = file.substr(Paths.replaceResponsesDir().length - 1);
+            console.log('Found file in replace-responses directory for url:', url);
+            files[url] = file;
           }
         }
       }
-    })
+    });
   }
 
-  const path = files[url]
+  const path = files[url];
   if (path) {
-    console.log('Replacing response for url', url)
-    return fs.readFileSync(path)
+    console.log('Replacing response for url', url);
+    return fs.readFileSync(path);
   }
-  return null
+  return null;
 }

--- a/server/src/SocketIoManager.ts
+++ b/server/src/SocketIoManager.ts
@@ -1,23 +1,23 @@
-import io from 'socket.io'
-import TcpProxy from './TcpProxy'
-import LogProxy from './LogProxy'
-import fs from 'fs'
-import ProxyConfig from '../../common/ProxyConfig'
-import Message, { MessageType } from '../../common/Message'
-import url from 'url'
-import net from 'net'
-import Ping from './Ping'
-import resend from './Resend'
-import GrpcProxy from './GrpcProxy'
-import Paths from './Paths'
-import Global from './Global'
+import io from 'socket.io';
+import TcpProxy from './TcpProxy';
+import LogProxy from './LogProxy';
+import fs from 'fs';
+import ProxyConfig from '../../common/ProxyConfig';
+import Message, { MessageType } from '../../common/Message';
+import url from 'url';
+import net from 'net';
+import Ping from './Ping';
+import resend from './Resend';
+import GrpcProxy from './GrpcProxy';
+import Paths from './Paths';
+import Global from './Global';
 
-const USE_HTTP2 = true
-const CONFIG_JSON = Paths.configJson()
-const CACHE_SOCKET_ID = 'cache'
+const USE_HTTP2 = true;
+const CONFIG_JSON = Paths.configJson();
+const CACHE_SOCKET_ID = 'cache';
 
-const WINDOW_SIZE = 500 // windows size - maximum outstanding messages
-const MAX_OUT = 2 // two message batches
+const WINDOW_SIZE = 500; // windows size - maximum outstanding messages
+const MAX_OUT = 2; // two message batches
 
 class SocketInfo {
     socket: io.Socket | undefined = undefined;
@@ -28,8 +28,8 @@ class SocketInfo {
     queuedMessages: Message[] = [];
 
     constructor (socket: io.Socket | undefined, configs: ProxyConfig[]) {
-      this.socket = socket
-      this.configs = configs
+      this.socket = socket;
+      this.configs = configs;
     }
 };
 
@@ -37,7 +37,7 @@ export default class SocketIoManager {
     private socketIoMap = new Map<string, SocketInfo>();
 
     constructor () {
-      this.activateConfig(this.getConfig())
+      this.activateConfig(this.getConfig());
     }
 
     private defaultConfig (): ProxyConfig[] {
@@ -53,106 +53,106 @@ export default class SocketIoManager {
           hostReachable: true,
           comment: ''
         }
-      ]
+      ];
     }
 
     public getConfig (): ProxyConfig[] {
       const configs = fs.existsSync(CONFIG_JSON)
         ? JSON.parse(fs.readFileSync(CONFIG_JSON).toString()).configs
-        : this.defaultConfig()
-      let modified = false
+        : this.defaultConfig();
+      let modified = false;
       for (const config of (configs as ProxyConfig[])) {
         if (config.protocol as string === 'proxy:') {
-          config.protocol = 'browser:'
-          modified = true
+          config.protocol = 'browser:';
+          modified = true;
         }
       }
-      modified && this.saveConfig(configs)
-      return configs
+      modified && this.saveConfig(configs);
+      return configs;
     }
 
     private resolveQueue: ((value: ProxyConfig[]) => void)[] = [];
 
     public updateHostReachable (): Promise<ProxyConfig[]> {
       return new Promise((resolve) => {
-        const configs = this.getConfig()
+        const configs = this.getConfig();
 
-        this.resolveQueue.push(resolve)
-        if (this.resolveQueue.length > 1) return
+        this.resolveQueue.push(resolve);
+        if (this.resolveQueue.length > 1) return;
 
-        let count = 0
+        let count = 0;
 
         const done = () => {
           if (++count === configs.length) {
             // const queueCount = this.resolveQueue.length
-            let func
+            let func;
             // eslint-disable-next-line no-cond-assign
             while (func = this.resolveQueue.pop()) {
-              func(configs)
+              func(configs);
             }
           }
-        }
+        };
         configs.forEach(config => {
           if (config.protocol === 'browser:' || config.protocol === 'log:') {
-            config.hostReachable = true
-            done()
+            config.hostReachable = true;
+            done();
           } else {
-            config.hostReachable = false
+            config.hostReachable = false;
             setTimeout(async () => {
-              const pingSuccessful = await Ping.host(config.hostname)
+              const pingSuccessful = await Ping.host(config.hostname);
               if (!pingSuccessful) {
-                done()
+                done();
               } else {
                 const socket = net.connect(config.port, config.hostname, () => {
-                  config.hostReachable = true
-                  socket.end()
-                  done()
-                })
+                  config.hostReachable = true;
+                  socket.end();
+                  done();
+                });
 
                 socket.on('error', (_err) => {
-                  done()
-                  socket.end()
-                })
+                  done();
+                  socket.end();
+                });
               }
-            })
+            });
           }
-        })
-      })
+        });
+      });
     }
 
     private saveConfig (proxyConfigs: ProxyConfig[]) {
       // Cache the config, to configure the proxy on the next start up prior
       // to receiving the config from the browser.
       fs.writeFileSync(CONFIG_JSON,
-        JSON.stringify({ configs: proxyConfigs }, null, 2))
+        JSON.stringify({ configs: proxyConfigs }, null, 2));
     }
 
     addHttpServer (httpServer: any) {
-      const server = new io.Server(httpServer)
-      server.on('connection', (socket: io.Socket) => this._socketConnection(socket))
+      const server = new io.Server(httpServer);
+      server.on('connection', (socket: io.Socket) => this._socketConnection(socket));
     }
 
     _socketConnection (socket: io.Socket) {
-      const config = this.getConfig()
+      const config = this.getConfig();
 
-      socket.emit('port config', Global.portConfig) // send port config to browser
+      socket.emit('port config', Global.portConfig); // send port config to browser
 
-      socket.emit('proxy config', config) // send config to browser
+      socket.emit('proxy config', config); // send config to browser
 
       socket.on('proxy config', (proxyConfigs: ProxyConfig[]) => {
-        console.log(`${Paths.configJson()}:\n`, proxyConfigs)
-        this.saveConfig(proxyConfigs)
+        console.log(`${Paths.configJson()}:\n`, proxyConfigs);
+        this.saveConfig(proxyConfigs);
 
         // Make sure all matching connection based servers are closed.
         for (const proxyConfig of proxyConfigs) {
           if (proxyConfig._server) {
-            this.closeAnyServerWithPort(proxyConfig.port)
+            this.closeAnyServerWithPort(proxyConfig.port);
           }
         }
 
-        this.activateConfig(proxyConfigs, socket)
+        this.activateConfig(proxyConfigs, socket);
         // this.updateHostReachable();
-      })
+      });
 
       socket.on('resend', (
         forwardProxy: boolean,
@@ -161,58 +161,58 @@ export default class SocketIoManager {
         message: Message,
         body?: string | object
       ) => {
-        resend(forwardProxy, method, url, message, body)
-      })
+        resend(forwardProxy, method, url, message, body);
+      });
 
       socket.on('disconnect', () => {
-        this.closeAnyServersWithSocket(socket.conn.id)
-        this.socketIoMap.delete(socket.conn.id)
-      })
+        this.closeAnyServersWithSocket(socket.conn.id);
+        this.socketIoMap.delete(socket.conn.id);
+      });
 
       socket.on('error', (e: any) => {
-        console.error('error', e)
-      })
+        console.error('error', e);
+      });
     }
 
     async activateConfig (proxyConfigs: ProxyConfig[], socket?: io.Socket) {
       for (const proxyConfig of proxyConfigs) {
         if (proxyConfig.protocol === 'log:') {
           // eslint-disable-next-line no-new
-          new LogProxy(proxyConfig)
+          new LogProxy(proxyConfig);
         } else if (proxyConfig.protocol === 'grpc:' && USE_HTTP2) {
-          GrpcProxy.reverseProxy(proxyConfig)
+          GrpcProxy.reverseProxy(proxyConfig);
         } else if (
           proxyConfig.protocol !== 'http:' &&
           proxyConfig.protocol !== 'https:' &&
           proxyConfig.protocol !== 'browser:'
         ) {
           // eslint-disable-next-line no-new
-          new TcpProxy(proxyConfig)
+          new TcpProxy(proxyConfig);
         }
       }
 
       this.socketIoMap.set(socket ? socket.conn.id : CACHE_SOCKET_ID,
-        new SocketInfo((socket || undefined), proxyConfigs))
+        new SocketInfo((socket || undefined), proxyConfigs));
       if (socket !== undefined) {
-        this.closeAnyServersWithSocket(CACHE_SOCKET_ID)
-        this.socketIoMap.delete(CACHE_SOCKET_ID)
+        this.closeAnyServersWithSocket(CACHE_SOCKET_ID);
+        this.socketIoMap.delete(CACHE_SOCKET_ID);
       }
     }
 
     // Close 'any:' protocol servers that are running for the browser owning the socket
     closeAnyServersWithSocket (socketId: string) {
       this.socketIoMap.forEach((socketInfo: SocketInfo, key: string) => {
-        if (socketId && key !== socketId) return
+        if (socketId && key !== socketId) return;
         for (const proxyConfig of socketInfo.configs) {
           if (proxyConfig.protocol === 'log:') {
-            LogProxy.destructor(proxyConfig)
+            LogProxy.destructor(proxyConfig);
           } if (proxyConfig.protocol === 'grpc:') {
-            GrpcProxy.destructor(proxyConfig)
+            GrpcProxy.destructor(proxyConfig);
           } else if (proxyConfig._server) {
-            TcpProxy.destructor(proxyConfig)
+            TcpProxy.destructor(proxyConfig);
           }
         }
-      })
+      });
     }
 
     // Close 'any:' protocol servers the specified listening port
@@ -221,21 +221,21 @@ export default class SocketIoManager {
         for (const proxyConfig of socketInfo.configs) {
           if (proxyConfig._server && proxyConfig.port === port) {
             if (proxyConfig.protocol === 'grpc:' && USE_HTTP2) {
-              GrpcProxy.destructor(proxyConfig)
+              GrpcProxy.destructor(proxyConfig);
             } else {
-              TcpProxy.destructor(proxyConfig)
+              TcpProxy.destructor(proxyConfig);
             }
           }
         }
-      })
+      });
     }
 
     isMatch (needle: string, haystack: string) {
       if (needle.indexOf('.*') !== -1) {
-        const match = haystack.match(needle)
-        return match !== null && match.length > 0
+        const match = haystack.match(needle);
+        return match !== null && match.length > 0;
       } else {
-        return haystack.startsWith(needle)
+        return haystack.startsWith(needle);
       }
     }
 
@@ -244,30 +244,33 @@ export default class SocketIoManager {
      * @params protocol
      * @params clientHostName
      * @param {*} reqUrl
+     * @param isForwardProxy
      * @returns ProxyConfig
      */
     findProxyConfigMatchingURL (
       protocol: 'http:' | 'https:',
       clientHostName: string,
-      reqUrl: url.UrlWithStringQuery): ProxyConfig|undefined {
-      const reqUrlPath = reqUrl.pathname!.replace(/\/\//g, '/')
-      const isForwardProxy = reqUrl.protocol !== null
+      reqUrl: url.UrlWithStringQuery,
+      proxyType: 'forward' | 'reverse' = 'reverse'
+    ): ProxyConfig|undefined {
+      const reqUrlPath = reqUrl.pathname!.replace(/\/\//g, '/');
+      const isForwardProxy = proxyType === 'forward';
 
-      let matchingProxyConfig: ProxyConfig|undefined
+      let matchingProxyConfig: ProxyConfig|undefined;
       // Find matching proxy configuration
       this.socketIoMap.forEach((socketInfo: SocketInfo, _key: string) => {
         for (const proxyConfig of socketInfo.configs) {
-          if (proxyConfig.protocol !== protocol && proxyConfig.protocol !== 'browser:') continue
+          if (proxyConfig.protocol !== protocol && proxyConfig.protocol !== 'browser:') continue;
           if ((this.isMatch(proxyConfig.path, reqUrlPath) ||
                     this.isMatch(proxyConfig.path, clientHostName + reqUrlPath)) &&
                     isForwardProxy === (proxyConfig.protocol === 'browser:')) {
             if (matchingProxyConfig === undefined || proxyConfig.path.length > matchingProxyConfig.path.length) {
-              matchingProxyConfig = proxyConfig
+              matchingProxyConfig = proxyConfig;
             }
           }
         }
-      })
-      return matchingProxyConfig
+      });
+      return matchingProxyConfig;
     }
 
     /**
@@ -276,26 +279,26 @@ export default class SocketIoManager {
      * @param {*} proxyConfig
      */
     emitMessageToBrowser (messageType:MessageType, message: Message, inProxyConfig?: ProxyConfig) {
-      message.type = messageType
-      const path = inProxyConfig ? inProxyConfig.path : ''
-      let socketId: string
-      let emitted = false
+      message.type = messageType;
+      const path = inProxyConfig ? inProxyConfig.path : '';
+      let socketId: string;
+      let emitted = false;
       this.socketIoMap.forEach((socketInfo: SocketInfo, key: string) => {
         for (const proxyConfig of socketInfo.configs) {
           if (inProxyConfig === undefined ||
                 (proxyConfig.path === path && inProxyConfig.protocol === proxyConfig.protocol)) {
-            if (key === socketId) continue
-            if (!proxyConfig.recording) continue
-            socketId = key
-            message.proxyConfig = proxyConfig
+            if (key === socketId) continue;
+            if (!proxyConfig.recording) continue;
+            socketId = key;
+            message.proxyConfig = proxyConfig;
             if (socketInfo.socket) {
-              this.emitMessageWithFlowControl([message], socketInfo, socketId)
-              emitted = true
+              this.emitMessageWithFlowControl([message], socketInfo, socketId);
+              emitted = true;
             }
-            if (inProxyConfig === undefined) break
+            if (inProxyConfig === undefined) break;
           }
         }
-      })
+      });
       if (!emitted) {
         // console.error(message.sequenceNumber, 'no browser socket to emit to', message.url)
       }
@@ -303,21 +306,21 @@ export default class SocketIoManager {
 
     private emitMessageWithFlowControl (messages: Message[], socketInfo: SocketInfo, socketId: string) {
       if (socketInfo.remainingWindow === 0 || socketInfo.messagesOut >= MAX_OUT) {
-        socketInfo.queuedMessages = socketInfo.queuedMessages.concat(messages)
+        socketInfo.queuedMessages = socketInfo.queuedMessages.concat(messages);
       } else {
         if (socketInfo.socket) {
-          const batchCount = messages.length
-          socketInfo.remainingWindow -= batchCount
-          ++socketInfo.seqNum
-          ++socketInfo.messagesOut
+          const batchCount = messages.length;
+          socketInfo.remainingWindow -= batchCount;
+          ++socketInfo.seqNum;
+          ++socketInfo.messagesOut;
           socketInfo.socket.emit(
             'reqResJson',
             messages,
             socketInfo.queuedMessages.length,
             // callback:
             (_response: string) => {
-              --socketInfo.messagesOut
-              socketInfo.remainingWindow += batchCount
+              --socketInfo.messagesOut;
+              socketInfo.remainingWindow += batchCount;
 
               // console.log(
               //             `out=${socketInfo.messagesOut}`,
@@ -325,16 +328,16 @@ export default class SocketIoManager {
               //             `queued=${socketInfo.queuedMessages.length}`,
               //             `(${response})`)
 
-              const count = Math.min(socketInfo.remainingWindow, socketInfo.queuedMessages.length)
+              const count = Math.min(socketInfo.remainingWindow, socketInfo.queuedMessages.length);
               if (count > 0) {
                 this.emitMessageWithFlowControl(
                   socketInfo.queuedMessages.splice(0, count),
                   socketInfo,
                   socketId
-                )
+                );
               }
             }
-          )
+          );
         }
       }
     }

--- a/server/src/SocketMessage.ts
+++ b/server/src/SocketMessage.ts
@@ -1,15 +1,15 @@
-import Message from '../../common/Message'
-import { IncomingHttpHeaders } from 'http'
-import Global from './Global'
+import Message from '../../common/Message';
+import { IncomingHttpHeaders } from 'http';
+import Global from './Global';
 
 export default class SocketMessage {
   public static buildRequest (timestamp: number, sequenceNumber: number, requestHeaders: IncomingHttpHeaders, method: string, url: string, endpoint: string, requestBody:string|{}, clientIp: string, serverHost: string, path:string, elapsedTime:number)
     : Promise<Message> {
-    return buildRequest(timestamp, sequenceNumber, requestHeaders, method, url, endpoint, requestBody, clientIp, serverHost, path, elapsedTime)
+    return buildRequest(timestamp, sequenceNumber, requestHeaders, method, url, endpoint, requestBody, clientIp, serverHost, path, elapsedTime);
   }
 
   public static appendResponse (message: Message, responseHeaders: {}, responseBody:{}|string, status:number, elapsedTime:number) {
-    appendResponse(message, responseHeaders, responseBody, status, elapsedTime)
+    appendResponse(message, responseHeaders, responseBody, status, elapsedTime);
   }
 };
 
@@ -18,13 +18,13 @@ async function buildRequest (timestamp:number, sequenceNumber:number, requestHea
   // eslint-disable-next-line no-async-promise-executor
   return new Promise<Message>(async (resolve) => {
     if (clientIp) {
-      clientIp = await Global.resolveIp(clientIp)
-      resolve(initMessage())
+      clientIp = await Global.resolveIp(clientIp);
+      resolve(initMessage());
     } else {
-      clientIp = 'unknown'
-      resolve(initMessage())
+      clientIp = 'unknown';
+      resolve(initMessage());
     }
-  })
+  });
 
   function initMessage (): Message {
     const message = {
@@ -43,15 +43,15 @@ async function buildRequest (timestamp:number, sequenceNumber:number, requestHea
       responseHeaders: {},
       responseBody: {},
       status: 0
-    }
-    return message as Message
+    };
+    return message as Message;
   }
 }
 
 function appendResponse (message: Message, responseHeaders: {}, responseBody: {}, status:number, elapsedTime:number) {
-  message.responseHeaders = responseHeaders
-  message.responseBody = responseBody
-  message.status = status
-  message.elapsedTime = elapsedTime
-  return message
+  message.responseHeaders = responseHeaders;
+  message.responseBody = responseBody;
+  message.status = status;
+  message.elapsedTime = elapsedTime;
+  return message;
 }

--- a/server/src/formatters/HexFormatter.ts
+++ b/server/src/formatters/HexFormatter.ts
@@ -1,31 +1,31 @@
 export default class HexFormatter {
   static format (buffer: Buffer) : string {
-    const hexStr = buffer.toString('hex')
-    let utf8Str = buffer.toString('utf8')
-    utf8Str = utf8Str.replace(/[^\x20-\x7E]/g, '.')
-    let strWithNewline = ''
-    let i = 0
-    let j = 0
-    let displayable = ''
+    const hexStr = buffer.toString('hex');
+    let utf8Str = buffer.toString('utf8');
+    utf8Str = utf8Str.replace(/[^\x20-\x7E]/g, '.');
+    let strWithNewline = '';
+    let i = 0;
+    let j = 0;
+    let displayable = '';
     for (; i + 8 < hexStr.length; i += 8, j += 4) {
-      strWithNewline += hexStr.substring(i, i + 8) + ' '
-      displayable += utf8Str.substring(j, j + 4)
+      strWithNewline += hexStr.substring(i, i + 8) + ' ';
+      displayable += utf8Str.substring(j, j + 4);
       if (i > 0 && (i + 8) % 32 === 0) {
-        strWithNewline += '  ' + displayable
-        displayable = ''
-        strWithNewline += '\n'
+        strWithNewline += '  ' + displayable;
+        displayable = '';
+        strWithNewline += '\n';
       }
     }
 
     if (i < hexStr.length) {
-      strWithNewline += hexStr.substring(i, hexStr.length)
+      strWithNewline += hexStr.substring(i, hexStr.length);
       if (hexStr.length % 32 !== 0) {
-        const pad = 32 - hexStr.length % 32
-        strWithNewline += (' '.repeat(pad + Math.ceil((pad + 1) / 8)))
+        const pad = 32 - hexStr.length % 32;
+        strWithNewline += (' '.repeat(pad + Math.ceil((pad + 1) / 8)));
       }
-      strWithNewline += ('  ' + displayable + utf8Str.substring(j, utf8Str.length))
+      strWithNewline += ('  ' + displayable + utf8Str.substring(j, utf8Str.length));
     }
 
-    return strWithNewline
+    return strWithNewline;
   }
 }

--- a/server/src/formatters/MongoFormatter.ts
+++ b/server/src/formatters/MongoFormatter.ts
@@ -1,42 +1,42 @@
-import { NO_RESPONSE } from '../../../common/Message'
-import HexFormatter from './HexFormatter'
-import MongoOpCode from './MongoOpCode'
+import { NO_RESPONSE } from '../../../common/Message';
+import HexFormatter from './HexFormatter';
+import MongoOpCode from './MongoOpCode';
 
 export default class SqlFormatter {
   formattedRequest: string;
   formattedResponse: string;
   command: string;
   constructor (reqBuf: Buffer, rspBuf: Buffer) {
-    this.formattedRequest = this._formatRequest(reqBuf)
-    this.formattedResponse = rspBuf ? this._formatResponse(rspBuf) : NO_RESPONSE
-    this.command = 'Request unknown'
+    this.formattedRequest = this._formatRequest(reqBuf);
+    this.formattedResponse = rspBuf ? this._formatResponse(rspBuf) : NO_RESPONSE;
+    this.command = 'Request unknown';
   }
 
-  getCommand (): string { return this.command }
+  getCommand (): string { return this.command; }
 
   /**
    * Get formatted request
   */
-  getRequest (): string { return this.formattedRequest }
+  getRequest (): string { return this.formattedRequest; }
 
   /**
    * Get formatted response
   */
-  getResponse (): string { return this.formattedResponse }
+  getResponse (): string { return this.formattedResponse; }
 
   _formatRequest (buf: Buffer): string {
-    const packet = new MongoPacket(buf)
-    const opCode = packet.getOpCode()
-    const requestID = packet.getRequestID()
-    const details = packet.getDetails()
-    return opCode + ' id=' + requestID + ' ' + details + '\n' + HexFormatter.format(buf) + '\n'
+    const packet = new MongoPacket(buf);
+    const opCode = packet.getOpCode();
+    const requestID = packet.getRequestID();
+    const details = packet.getDetails();
+    return opCode + ' id=' + requestID + ' ' + details + '\n' + HexFormatter.format(buf) + '\n';
   }
 
   _formatResponse (buf: Buffer): string {
-    const packet = new MongoPacket(buf)
-    const flags = packet.getResponseFlags()
-    const numberReturned = packet.getNumberReturned()
-    return `\nflags=${flags} documents=${numberReturned}\n\n${HexFormatter.format(buf)}\n`
+    const packet = new MongoPacket(buf);
+    const flags = packet.getResponseFlags();
+    const numberReturned = packet.getNumberReturned();
+    return `\nflags=${flags} documents=${numberReturned}\n\n${HexFormatter.format(buf)}\n`;
   }
 }
 
@@ -52,65 +52,65 @@ class MongoPacket {
   responseFlags: string = '';
   numberReturned: number = 0;
   constructor (buf: Buffer) {
-    this.buf = buf
-    this.offset = 0
-    this.messageLength = buf.readInt32LE(0)
-    this.requestID = buf.readInt32LE(4)
-    this.responseTo = buf.readInt32LE(8)
-    this.opCode = MongoOpCode.toString(buf.readInt32LE(12))
+    this.buf = buf;
+    this.offset = 0;
+    this.messageLength = buf.readInt32LE(0);
+    this.requestID = buf.readInt32LE(4);
+    this.responseTo = buf.readInt32LE(8);
+    this.opCode = MongoOpCode.toString(buf.readInt32LE(12));
 
-    this.details = ''
+    this.details = '';
     switch (this.opCode) {
       case MongoOpCode.OP_UPDATE:
       case MongoOpCode.OP_INSERT:
       case MongoOpCode.OP_QUERY:
       case MongoOpCode.OP_GET_MORE:
       case MongoOpCode.OP_DELETE:
-        this.details = cstring(20) // fullCollectionName
-        break
+        this.details = cstring(20); // fullCollectionName
+        break;
       case MongoOpCode.OP_REPLAY: {
-        this.responseFlags = 'none'
-        const flags = buf.readInt32LE(16)
+        this.responseFlags = 'none';
+        const flags = buf.readInt32LE(16);
         switch (flags) {
           case 0:
-            this.responseFlags = 'CursorNotFound'
-            break
+            this.responseFlags = 'CursorNotFound';
+            break;
           case 1:
-            this.responseFlags = 'QueryFailure'
-            break
+            this.responseFlags = 'QueryFailure';
+            break;
           case 2:
-            this.responseFlags = 'ShardConfigState'
-            break
+            this.responseFlags = 'ShardConfigState';
+            break;
           case 3:
-            this.responseFlags = 'AwaitCapable'
-            break
+            this.responseFlags = 'AwaitCapable';
+            break;
         }
-        this.numberReturned = buf.readInt32LE(32)
-        break
+        this.numberReturned = buf.readInt32LE(32);
+        break;
       }
     }
 
     function cstring (start: number) {
-      let end = start
+      let end = start;
       for (; buf.readUInt8(end) !== 0; ++end);
-      const str = buf.toString('utf8', start, end)
-      return str
+      const str = buf.toString('utf8', start, end);
+      return str;
     }
   }
 
-  getOffset (): number { return this.offset }
+  getOffset (): number { return this.offset; }
 
-  getMessageLength (): number { return this.messageLength }
+  getMessageLength (): number { return this.messageLength; }
 
-  getRequestID (): number { return this.requestID }
+  getRequestID (): number { return this.requestID; }
 
-  getResponseTo (): number { return this.requestID }
+  getResponseTo (): number { return this.requestID; }
 
-  getOpCode (): string { return this.opCode }
+  getOpCode (): string { return this.opCode; }
 
-  getDetails (): string { return this.details }
+  getDetails (): string { return this.details; }
 
-  getResponseFlags (): string { return this.responseFlags }
+  getResponseFlags (): string { return this.responseFlags; }
 
-  getNumberReturned (): number { return this.numberReturned }
+  getNumberReturned (): number { return this.numberReturned; }
 }

--- a/server/src/formatters/MongoOpCode.ts
+++ b/server/src/formatters/MongoOpCode.ts
@@ -10,39 +10,39 @@ export default class MongoOpCode {
   static OP_MSG = 'OP_MSG';
 
   static toString (opCode: number): string {
-    let str
+    let str;
     switch (opCode) {
       case 1:
-        str = MongoOpCode.OP_REPLAY
-        break
+        str = MongoOpCode.OP_REPLAY;
+        break;
       case 2001:
-        str = MongoOpCode.OP_UPDATE
-        break
+        str = MongoOpCode.OP_UPDATE;
+        break;
       case 2002:
-        str = MongoOpCode.OP_INSERT
-        break
+        str = MongoOpCode.OP_INSERT;
+        break;
       case 2003:
-        str = MongoOpCode.OP_GET_BY_OID
-        break
+        str = MongoOpCode.OP_GET_BY_OID;
+        break;
       case 2004:
-        str = MongoOpCode.OP_QUERY
-        break
+        str = MongoOpCode.OP_QUERY;
+        break;
       case 2005:
-        str = MongoOpCode.OP_GET_MORE
-        break
+        str = MongoOpCode.OP_GET_MORE;
+        break;
       case 2006:
-        str = MongoOpCode.OP_DELETE
-        break
+        str = MongoOpCode.OP_DELETE;
+        break;
       case 2007:
-        str = MongoOpCode.OP_KILL_CURSORS
-        break
+        str = MongoOpCode.OP_KILL_CURSORS;
+        break;
       case 2013:
-        str = MongoOpCode.OP_MSG
-        break
+        str = MongoOpCode.OP_MSG;
+        break;
       default:
-        str = 'Unknown Command'
-        break
+        str = 'Unknown Command';
+        break;
     }
-    return str
+    return str;
   }
 }

--- a/server/src/formatters/RedisFormatter.ts
+++ b/server/src/formatters/RedisFormatter.ts
@@ -1,28 +1,28 @@
-import { NO_RESPONSE } from '../../../common/Message'
+import { NO_RESPONSE } from '../../../common/Message';
 
 export default class RedisFormatter {
   formattedRequest: any;
   formattedResponse: string;
   constructor (reqBuf: Buffer, rspBuf: Buffer) {
-    this.formattedRequest = this._formatRequest(reqBuf)
-    this.formattedResponse = rspBuf ? this._formatResponse(rspBuf) : NO_RESPONSE
+    this.formattedRequest = this._formatRequest(reqBuf);
+    this.formattedResponse = rspBuf ? this._formatResponse(rspBuf) : NO_RESPONSE;
   }
 
   /**
    * Get formatted request
    */
-  getRequest (): string { return this.formattedRequest }
+  getRequest (): string { return this.formattedRequest; }
 
   /**
    * Get formatted response
    */
-  getResponse (): string { return this.formattedResponse }
+  getResponse (): string { return this.formattedResponse; }
 
   _formatRequest (buf: Buffer): string {
-    return buf.toString('utf8').split('\r\n').join('\n')
+    return buf.toString('utf8').split('\r\n').join('\n');
   }
 
   _formatResponse (buf: Buffer): string {
-    return '\n' + buf.toString('utf8').split('\r\n').join('\n')
+    return '\n' + buf.toString('utf8').split('\r\n').join('\n');
   }
 }

--- a/server/src/formatters/SqlCommand.ts
+++ b/server/src/formatters/SqlCommand.ts
@@ -1,108 +1,108 @@
 
 export default class SqlCommand {
   static toString (command: number): string {
-    let str
+    let str;
     switch (command) {
       case 0:
-        str = 'Sleep'
-        break
+        str = 'Sleep';
+        break;
       case 1:
-        str = 'Quit'
-        break
+        str = 'Quit';
+        break;
       case 2:
-        str = 'Use Database'
-        break
+        str = 'Use Database';
+        break;
       case 3:
-        str = 'Query'
-        break
+        str = 'Query';
+        break;
       case 4:
-        str = 'Field List'
-        break
+        str = 'Field List';
+        break;
       case 5:
-        str = 'Create Database'
-        break
+        str = 'Create Database';
+        break;
       case 6:
-        str = 'Field List'
-        break
+        str = 'Field List';
+        break;
       case 7:
-        str = 'Refresh'
-        break
+        str = 'Refresh';
+        break;
       case 8:
-        str = 'Shutdown'
-        break
+        str = 'Shutdown';
+        break;
       case 9:
-        str = 'Statistics'
-        break
+        str = 'Statistics';
+        break;
       case 10:
-        str = 'Process Info'
-        break
+        str = 'Process Info';
+        break;
       case 11:
-        str = 'Connect'
-        break
+        str = 'Connect';
+        break;
       case 12:
-        str = 'Process Kill'
-        break
+        str = 'Process Kill';
+        break;
       case 13:
-        str = 'Debug'
-        break
+        str = 'Debug';
+        break;
       case 14:
-        str = 'Ping'
-        break
+        str = 'Ping';
+        break;
       case 15:
-        str = 'Time'
-        break
+        str = 'Time';
+        break;
       case 16:
-        str = 'Delayed Insert'
-        break
+        str = 'Delayed Insert';
+        break;
       case 17:
-        str = 'Change User'
-        break
+        str = 'Change User';
+        break;
       case 18:
-        str = 'BINLOG Dump'
-        break
+        str = 'BINLOG Dump';
+        break;
       case 19:
-        str = 'Table Dump'
-        break
+        str = 'Table Dump';
+        break;
       case 20:
-        str = 'Connect Out'
-        break
+        str = 'Connect Out';
+        break;
       case 21:
-        str = 'Register Slave'
-        break
+        str = 'Register Slave';
+        break;
       case 22:
-        str = 'Prepare'
-        break
+        str = 'Prepare';
+        break;
       case 23:
-        str = 'Execute'
-        break
+        str = 'Execute';
+        break;
       case 24:
-        str = 'Send Long Data'
-        break
+        str = 'Send Long Data';
+        break;
       case 25:
-        str = 'Close'
-        break
+        str = 'Close';
+        break;
       case 26:
-        str = 'Reset'
-        break
+        str = 'Reset';
+        break;
       case 27:
-        str = 'Set Option'
-        break
+        str = 'Set Option';
+        break;
       case 28:
-        str = 'Fetch'
-        break
+        str = 'Fetch';
+        break;
       case 29:
-        str = 'Daemon'
-        break
+        str = 'Daemon';
+        break;
       case 30:
-        str = 'BINLOG Dump GTID'
-        break
+        str = 'BINLOG Dump GTID';
+        break;
       case 31:
-        str = 'Reset Connection'
-        break
+        str = 'Reset Connection';
+        break;
       default:
-        str = 'Unknown Command'
-        break
+        str = 'Unknown Command';
+        break;
     }
-    return str
+    return str;
   }
 }

--- a/server/src/formatters/SqlFormatter.ts
+++ b/server/src/formatters/SqlFormatter.ts
@@ -1,7 +1,7 @@
-import sqlFormatter from 'sql-formatter'
-import { NO_RESPONSE } from '../../../common/Message'
-import HexFormatter from './HexFormatter'
-import SqlCommand from './SqlCommand'
+import sqlFormatter from 'sql-formatter';
+import { NO_RESPONSE } from '../../../common/Message';
+import HexFormatter from './HexFormatter';
+import SqlCommand from './SqlCommand';
 
 export default class SqlFormatter {
   formattedQuery: any;
@@ -10,77 +10,77 @@ export default class SqlFormatter {
   errorCode: number;
 
   constructor (reqBuf: Buffer, rspBuf: Buffer) {
-    this.errorCode = 0
-    this.formattedQuery = this._formatQuery(reqBuf)
+    this.errorCode = 0;
+    this.formattedQuery = this._formatQuery(reqBuf);
     this.formattedResults = rspBuf
       ? (this.getCommand() === 'Query'
           ? this._formatResults(rspBuf)
           : HexFormatter.format(rspBuf))
       : this.getCommand() === 'Quit'
         ? 'Closed'
-        : NO_RESPONSE
-    this.command = 'Request unknown'
+        : NO_RESPONSE;
+    this.command = 'Request unknown';
   }
 
-  getCommand (): string { return this.command }
+  getCommand (): string { return this.command; }
 
   /**
    * Get formatted query
    */
-  getQuery (): string { return this.formattedQuery }
+  getQuery (): string { return this.formattedQuery; }
 
   /**
    * Get formatted results
    */
-  getResults (): string { return this.formattedResults }
+  getResults (): string { return this.formattedResults; }
 
   _formatQuery (buf: Buffer): string {
-    const packet = new MySqlPacket(buf)
+    const packet = new MySqlPacket(buf);
     if (packet.getNumber() === 1) {
-      this.command = 'Login Request'
+      this.command = 'Login Request';
     } else {
-      const command = buf.readUInt8(4)
-      this.command = SqlCommand.toString(command)
+      const command = buf.readUInt8(4);
+      this.command = SqlCommand.toString(command);
       if (this.command === 'Query') {
-        const str = buf.toString('utf8', 5) // query string
-        const command = ''
-        return command + sqlFormatter.format(str.split('\n').join(' '))
+        const str = buf.toString('utf8', 5); // query string
+        const command = '';
+        return command + sqlFormatter.format(str.split('\n').join(' '));
       }
     }
 
-    return this.command + '\n' + HexFormatter.format(buf)
+    return this.command + '\n' + HexFormatter.format(buf);
   }
 
   getErrorCode (): number {
-    return this.errorCode
+    return this.errorCode;
   }
 
   _formatResults (buf: Buffer): string {
-    const formattedResults: string[] = []
-    let fieldCount = 0
-    let rowCount = 0
-    let truncated = false
+    const formattedResults: string[] = [];
+    let fieldCount = 0;
+    let rowCount = 0;
+    let truncated = false;
     try {
-      const packet = new MySqlPacket(buf) // keep track of Payload Packet offset
-      let pktOffset = packet.nextOffset() // get next (second) payload packet
+      const packet = new MySqlPacket(buf); // keep track of Payload Packet offset
+      let pktOffset = packet.nextOffset(); // get next (second) payload packet
 
-      fieldCount = buf.readUInt8(4) // number of rows
+      fieldCount = buf.readUInt8(4); // number of rows
 
       // Error?
       if (fieldCount === 255) {
-        this.errorCode = buf.readUInt16LE(5)
-        return HexFormatter.format(buf)
+        this.errorCode = buf.readUInt16LE(5);
+        return HexFormatter.format(buf);
       }
 
-      const colNames = []
+      const colNames = [];
       for (let i = 0; i < fieldCount; ++i) {
-        let subCvOffset = pktOffset! + 4 // offset to data in payload packet
+        let subCvOffset = pktOffset! + 4; // offset to data in payload packet
         for (let j = 0; j < 4; ++j) { // 4th sub payload packet is column name
-          subCvOffset += buf.readUInt8(subCvOffset) + 1 // next sub payload packet
+          subCvOffset += buf.readUInt8(subCvOffset) + 1; // next sub payload packet
         }
-        colNames.push(buf.toString('utf8', subCvOffset + 1, subCvOffset + 1 + buf.readUInt8(subCvOffset)))
+        colNames.push(buf.toString('utf8', subCvOffset + 1, subCvOffset + 1 + buf.readUInt8(subCvOffset)));
 
-        pktOffset = packet.nextOffset() // next payload packet
+        pktOffset = packet.nextOffset(); // next payload packet
       }
 
       for (; pktOffset !== null; pktOffset = packet.nextOffset(), ++rowCount) {
@@ -91,49 +91,49 @@ export default class SqlFormatter {
 
         if (pktOffset !== null) {
           // Get values for each columns
-          let subCvOffset = pktOffset + 4 // offset to first sub payload packet
+          let subCvOffset = pktOffset + 4; // offset to first sub payload packet
           for (let i = 0; i < fieldCount; ++i) {
             if (subCvOffset >= buf.length) {
-              truncated = true
-              break
+              truncated = true;
+              break;
             }
 
-            const len = buf.readUInt8(subCvOffset)
-            const isNull = (len === 251)
+            const len = buf.readUInt8(subCvOffset);
+            const isNull = (len === 251);
 
-            subCvOffset += 1 // value after length
+            subCvOffset += 1; // value after length
 
-            const colName = colNames[i]
-            const fieldValue = isNull ? 'NULL' : buf.toString('utf8', subCvOffset, subCvOffset + len)
-            formattedResults.push(`  ${colName} = ${fieldValue}`)
-            if (!isNull) subCvOffset += len
+            const colName = colNames[i];
+            const fieldValue = isNull ? 'NULL' : buf.toString('utf8', subCvOffset, subCvOffset + len);
+            formattedResults.push(`  ${colName} = ${fieldValue}`);
+            if (!isNull) subCvOffset += len;
           }
         }
       }
 
-      return stringifyResults() + (truncated ? '\nResults are truncated\n' : '')
+      return stringifyResults() + (truncated ? '\nResults are truncated\n' : '');
     } catch (e) {
       if (formattedResults.length > 0) {
-        return stringifyResults() + '\n' + e + '\n' // + new Error().stack.replace(/\n/g, '\n');
+        return stringifyResults() + '\n' + e + '\n'; // + new Error().stack.replace(/\n/g, '\n');
       } else {
-        return HexFormatter.format(buf)
+        return HexFormatter.format(buf);
       }
     }
 
     function stringifyResults (): string {
-      const totalCount = (rowCount - 1) + (truncated ? ' (partial results)' : '')
+      const totalCount = (rowCount - 1) + (truncated ? ' (partial results)' : '');
       for (let i = 0; i < rowCount - 1; ++i) {
-        formattedResults.splice(i * fieldCount + (i * 2), 0, `{ /* ${i + 1} of ${totalCount} */`)
-        formattedResults.splice((i + 1) * fieldCount + (i * 2) + 1, 0, '}')
+        formattedResults.splice(i * fieldCount + (i * 2), 0, `{ /* ${i + 1} of ${totalCount} */`);
+        formattedResults.splice((i + 1) * fieldCount + (i * 2) + 1, 0, '}');
       }
-      let string = ''
+      let string = '';
       for (let i = 0; i < formattedResults.length; ++i) {
-        string += formattedResults[i] + '\n'
+        string += formattedResults[i] + '\n';
       }
       if (string.length === 0) {
-        string = 'No results'
+        string = 'No results';
       }
-      return string
+      return string;
     }
   }
 }
@@ -145,31 +145,31 @@ class MySqlPacket {
   packetLength: any;
   packetNumber: any;
   constructor (buf: Buffer) {
-    this.buf = buf
-    this.offset = 0
-    this.packetLength = this.toUInt24(0)
-    this.packetNumber = buf.readUInt8(3)
+    this.buf = buf;
+    this.offset = 0;
+    this.packetLength = this.toUInt24(0);
+    this.packetNumber = buf.readUInt8(3);
   }
 
   toUInt24 (offset: number): number {
-    return this.buf.readUInt8(offset) + (this.buf.readUInt8(offset + 1) << 8) + (this.buf.readUInt8(offset + 2) << 16)
+    return this.buf.readUInt8(offset) + (this.buf.readUInt8(offset + 1) << 8) + (this.buf.readUInt8(offset + 2) << 16);
   }
 
   // Move offset to next packet
   nextOffset (): number|null {
-    const offset = this.offset + this.toUInt24(this.offset) + 4
-    if (offset + 4 >= this.buf.length) return null
+    const offset = this.offset + this.toUInt24(this.offset) + 4;
+    if (offset + 4 >= this.buf.length) return null;
 
-    this.offset = offset
-    this.packetLength = this.toUInt24(offset)
-    this.packetNumber = this.buf.readUInt8(offset + 3)
+    this.offset = offset;
+    this.packetLength = this.toUInt24(offset);
+    this.packetNumber = this.buf.readUInt8(offset + 3);
 
-    return offset
+    return offset;
   }
 
-  getOffset (): number { return this.offset }
+  getOffset (): number { return this.offset; }
 
-  getLength (): number { return this.packetLength }
+  getLength (): number { return this.packetLength; }
 
-  getNumber (): number { return this.packetNumber }
+  getNumber (): number { return this.packetNumber; }
 }


### PR DESCRIPTION
The --http2 option enables an HTTP/2 connection to the remote server.   The AllProxy will use the HTTP version 2 to connect to remote servers.  If the remote server does not support HTTP/2, the HTTP version is downgraded to 1.1.