### PR TITLE
Stop auto-scroll when request is selected

### DIFF
--- a/client/src/components/SnapshotTabContent.tsx
+++ b/client/src/components/SnapshotTabContent.tsx
@@ -78,7 +78,7 @@ const SnapshotTabContent = observer(({
 								/>)
 						}
 					})}
-					{matchCount > 0 && messageQueueStore.getAutoScroll() && setScrollTo(lastSeqNum)}
+					{matchCount > 0 && messageQueueStore.getAutoScroll() && selectedReqSeqNum === Number.MAX_SAFE_INTEGER && setScrollTo(lastSeqNum)}
 					{matchCount === 0 && (
 						<div className="center">
 							No matching request or response found.  Adjust your filter criteria.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allproxy",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "allproxy",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "AllProxy: HTTP, SQL, gRPC Debugging Tool.",
   "keywords": [
     "proxy",

--- a/server/src/TcpProxy.ts
+++ b/server/src/TcpProxy.ts
@@ -86,11 +86,11 @@ export default class TcpProxy {
           }
 
           sourceSocket.on('error', (err: any) => {
-            console.error(`TcpProxy client error ${sourcePort}: ${err}`);
+            Global.log(`TcpProxy client error ${sourcePort}: ${err}`);
           });
 
           targetSocket.on('error', (err) => {
-            console.error(`TcpProxy server error ${sourcePort}: ${err}`);
+            Global.log(`TcpProxy server error ${sourcePort}: ${err}`);
           });
 
           // Handle data from source (client)


### PR DESCRIPTION
If auto scroll is enabled, and a request is selected, the selected request will scroll off the screen.  This PR stops the auto scrolling when a request is selected to allow the user to view the request/response.  When the request is closed, the auto scrolling will resume again.