### PR TITLE
Improve filter performance when messages are being received

### DIFF
--- a/client/src/components/BreakpointModal.tsx
+++ b/client/src/components/BreakpointModal.tsx
@@ -33,7 +33,7 @@ const BreakpointModal = observer(({ open, onClose, store }: Props) => {
 	}
 
 	function handleValueChange(e: any, breakpoint: FilterStore) {
-		breakpoint.setFilter(e.currentTarget.value);
+		breakpoint.setFilterNoDebounce(e.currentTarget.value);
 		store.changed();
 	}
 

--- a/client/src/store/BreakpointStore.ts
+++ b/client/src/store/BreakpointStore.ts
@@ -33,7 +33,7 @@ export default class BreakpointStore {
 				_logical: boolean }) => {
 				const breakpoint = new FilterStore();
 				breakpoint.setEnabled(entry.enabled);
-				breakpoint.setFilter(entry.searchFilter);
+				breakpoint.setFilterNoDebounce(entry.searchFilter);
 				breakpoint.setRegex(entry._regex);
 				breakpoint.setMatchCase(!!entry._matchCase);
 				breakpoint.setLogical(!!entry._logical);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "2.5.34",
+  "version": "2.5.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "2.5.34",
+  "version": "2.5.35",
   "description": "AllProxy: HTTP, SQL, gRPC Debugging Tool.",
   "keywords": [
     "proxy",


### PR DESCRIPTION
When there are a steady stream of messages being captured, and the user is updating the filter the browser can become unresponsive, because React is overwhelmed with updates from newly captured messages, and updates deriving by the using entered input filter.

The incoming capture updates will be temporarily frozen while the using is entering the input filter.  This will allow React to update only one thing at a time.