### PR TITLE
Tweak Scrolling

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -169,7 +169,7 @@ const Header = observer(({ socketStore, messageQueueStore, snapshotStore, filter
 			</div>
 			<div>
 				<div className="header__count" title="Received messages">
-					<div>{getDisplayedCount()+' of '+messageQueueStore.getMessages().length}</div>
+					<div>{getDisplayedCount()+' of '+messageQueueStore.getTotalLength()}</div>
 				</div>				
 			</div>
 			<div>

--- a/client/src/components/SnapshotTabContent.tsx
+++ b/client/src/components/SnapshotTabContent.tsx
@@ -136,6 +136,26 @@ const SnapshotTabContent = observer(({
 		const parent = (ref.current as Element);
 		if (parent && parent.childNodes.length > 0) {
 			setScrollTop(parent.scrollTop);
+			// If the last message is visible, we need setFreeze(false) to cause 
+			// all queued messages to be merged into the message queue, and become
+			// visible.
+			setTimeout(() => {				
+				const parent = (ref.current as Element);
+				if (parent && parent.childNodes.length > 0) {
+					const children = parent.childNodes;
+					let i = messageQueueStore.getMessages().length - 1;
+					i = Math.max(0,i-1);
+					const element = (children[i] as Element);
+					if (element) {
+						const top = element.getBoundingClientRect().top;
+						console.log(top)
+						if (top <= 800) {
+							messageQueueStore.setFreeze(false);
+							setTimeout(handleScroll, 1000);
+						}
+					}
+				}
+			});
 		}
 	}
 

--- a/client/src/store/MessageQueueStore.ts
+++ b/client/src/store/MessageQueueStore.ts
@@ -90,10 +90,21 @@ export default class MessageQueueStore {
 		return snapshotStore.getSelectedMessages();
 	}
 
+	public getTotalLength() {
+		let count = this.getMessages().length;
+		if (snapshotStore.isActiveSnapshotSelected()) {
+			count += this.freezeQ.length;
+		}
+		return count;
+	}
+
 	@action public insertBatch(messages: Message[]) {
-		if (this.stopped) return;
+		if (this.stopped) return;		
 		if (this.freeze) {
 			this.freezeQ = this.freezeQ.concat(messages);
+			if (this.freezeQ.length > this.limit) {
+				this.setFreeze(false);
+			}
 			return;
 		}
 
@@ -148,12 +159,12 @@ export default class MessageQueueStore {
 			}
 
 			// Shrink array
-			if (copyMessages.length >= this.limit + this.limit / 2) {
+			if (copyMessages.length > this.limit) {
 				copyMessages.splice(0, copyMessages.length - this.limit);
 			}
 		}
 
-		activeSnapshot.splice(0, activeSnapshot.length);
+		activeSnapshot.splice(0, activeSnapshot.length);		
 		Array.prototype.push.apply(activeSnapshot, copyMessages);
 	}
 }

--- a/client/src/store/SocketStore.ts
+++ b/client/src/store/SocketStore.ts
@@ -11,6 +11,7 @@ import { mapProtocolToIndex } from './MetricsStore';
 import { noCaptureStore } from "./NoCaptureStore";
 import { filterStore } from "./FilterStore";
 import MessageStore from "./MessageStore";
+import { snapshotStore } from "./SnapshotStore";
 
 export default class SocketStore {
 	private socket?: Socket = undefined;
@@ -72,6 +73,10 @@ export default class SocketStore {
 					return true;
 				}
 			);
+			
+			if (snapshotStore.getActiveSnapshot().length + filteredMessages.length > messageQueueStore.getLimit()) {
+				messageQueueStore.setFreeze(true)
+			}
 			messageQueueStore.insertBatch(filteredMessages);
 
 			if (callback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "2.5.36",
+  "version": "2.5.37",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allproxy",
-  "version": "2.5.36",
+  "version": "2.5.37",
   "description": "AllProxy: HTTP, SQL, gRPC Debugging Tool.",
   "keywords": [
     "proxy",


### PR DESCRIPTION
When captured message limit is reached, the message queue array is truncated at the start of the array, and the scroll area begins to jump around.

These changes will be made to prevent the scroll area from jumping around when the message queue limit is reach:
1. The start of the message queue array will not be truncated, until 2 times the message queue limit is reached.
2. If the user scrolls beyond to the last message, new messages will be added to the message queue to using an infinite like scrolling behavior.